### PR TITLE
Support HTTP/1.1 keep-alive in MITM proxy (fixes #7)

### DIFF
--- a/src/proxy/mitm.ts
+++ b/src/proxy/mitm.ts
@@ -194,95 +194,157 @@ export function startMitmProxy(mockPort: number, proxyPort: number): http.Server
 }
 
 function handleInterceptedRequest(tlsSocket: tls.TLSSocket, hostname: string, mockPort: number): void {
+  // One TLS socket can carry many HTTP/1.1 requests via keep-alive. The
+  // previous implementation handled exactly one request and then called
+  // tlsSocket.end(), which broke any client (gh, gws) that pipelined or
+  // reused the connection — the second request raced against the close
+  // and surfaced as `Post ...: EOF`. This rewrite keeps the socket open
+  // and processes requests in a loop until the client / upstream signals
+  // Connection: close.
+
   let buffer = Buffer.alloc(0);
+  let processing = false;
+  let closed = false;
 
-  const onData = (chunk: Buffer) => {
-    buffer = Buffer.concat([buffer, chunk]);
+  const closeSocket = () => {
+    if (closed) return;
+    closed = true;
+    try {
+      tlsSocket.end();
+    } catch {}
+  };
 
-    // Check if we have a complete HTTP request header
+  const writeAndClose = (resp: string) => {
+    if (closed) return;
+    try {
+      tlsSocket.write(resp);
+    } catch {}
+    closeSocket();
+  };
+
+  const tryProcessNext = () => {
+    if (processing || closed) return;
+
     const headerEnd = buffer.indexOf('\r\n\r\n');
     if (headerEnd === -1) return; // wait for more data
 
-    tlsSocket.removeListener('data', onData);
-
     const headerStr = buffer.subarray(0, headerEnd).toString('utf-8');
-    const bodyStart = buffer.subarray(headerEnd + 4);
-
     const [requestLine, ...headerLines] = headerStr.split('\r\n');
     const [method, urlPath] = requestLine.split(' ');
 
-    // Parse headers
     const headers: Record<string, string> = {};
     let contentLength = 0;
+    let clientWantsClose = false;
     for (const line of headerLines) {
       const colonIdx = line.indexOf(':');
       if (colonIdx > 0) {
         const key = line.slice(0, colonIdx).trim().toLowerCase();
         const val = line.slice(colonIdx + 1).trim();
         headers[key] = val;
-        if (key === 'content-length') contentLength = parseInt(val);
+        if (key === 'content-length') contentLength = parseInt(val) || 0;
+        else if (key === 'connection' && val.toLowerCase() === 'close') clientWantsClose = true;
       }
     }
 
-    // Collect body if present
-    const collectBody = (bodyBuf: Buffer) => {
-      // Forward to mock server
-      const mockReq = http.request({
+    // Wait for the full body before forwarding. NOTE: this proxy does not
+    // support Transfer-Encoding: chunked on the *request* side. gh and gws
+    // both buffer requests and send a Content-Length, so this is fine in
+    // practice. If a future client uses chunked we'll need to add it.
+    const bodyAvailable = buffer.length - (headerEnd + 4);
+    if (bodyAvailable < contentLength) return; // wait for more body data
+
+    const bodyBuf = buffer.subarray(headerEnd + 4, headerEnd + 4 + contentLength);
+    // Trim the consumed bytes off the buffer; anything left is part of the
+    // next pipelined request.
+    buffer = buffer.subarray(headerEnd + 4 + contentLength);
+
+    processing = true;
+    forwardRequest(method, urlPath, headers, bodyBuf, clientWantsClose);
+  };
+
+  const forwardRequest = (
+    method: string,
+    urlPath: string,
+    headers: Record<string, string>,
+    bodyBuf: Buffer,
+    clientWantsClose: boolean,
+  ) => {
+    const mockReq = http.request(
+      {
         hostname: 'localhost',
         port: mockPort,
         path: urlPath,
         method,
-        headers: {
-          ...headers,
-          host: `localhost:${mockPort}`,
-        },
-      }, (mockRes) => {
-        // Send response back through TLS socket
-        let respHeader = `HTTP/1.1 ${mockRes.statusCode} ${mockRes.statusMessage}\r\n`;
-        for (const [key, val] of Object.entries(mockRes.headers)) {
-          if (val) {
+        headers: { ...headers, host: `localhost:${mockPort}` },
+      },
+      (mockRes) => {
+        // Buffer the upstream response so we can write it as a single
+        // chunk and decide whether to close the TLS socket afterwards.
+        // For mock-server traffic the responses are small, so buffering
+        // is acceptable.
+        const chunks: Buffer[] = [];
+        mockRes.on('data', (c: Buffer) => chunks.push(c));
+        mockRes.on('end', () => {
+          if (closed) return;
+
+          const body = Buffer.concat(chunks);
+          let respHeader = `HTTP/1.1 ${mockRes.statusCode ?? 502} ${mockRes.statusMessage ?? ''}\r\n`;
+          let upstreamWantsClose = false;
+          for (const [key, val] of Object.entries(mockRes.headers)) {
+            if (val == null) continue;
             const vals = Array.isArray(val) ? val : [val];
             for (const v of vals) {
               respHeader += `${key}: ${v}\r\n`;
+              if (key.toLowerCase() === 'connection' && String(v).toLowerCase() === 'close') {
+                upstreamWantsClose = true;
+              }
             }
           }
-        }
-        respHeader += '\r\n';
+          respHeader += '\r\n';
 
-        tlsSocket.write(respHeader);
-        mockRes.pipe(tlsSocket);
-        mockRes.on('end', () => {
-          tlsSocket.end();
+          try {
+            tlsSocket.write(respHeader);
+            if (body.length > 0) tlsSocket.write(body);
+          } catch {
+            closeSocket();
+            return;
+          }
+
+          processing = false;
+
+          if (clientWantsClose || upstreamWantsClose) {
+            closeSocket();
+          } else {
+            // Defer so any newly-arrived bytes get flushed onto `buffer`
+            // before we look at it again.
+            setImmediate(tryProcessNext);
+          }
         });
-      });
+        mockRes.on('error', () => {
+          processing = false;
+          writeAndClose('HTTP/1.1 502 Bad Gateway\r\nContent-Length: 0\r\nConnection: close\r\n\r\n');
+        });
+      },
+    );
 
-      mockReq.on('error', () => {
-        tlsSocket.write('HTTP/1.1 502 Bad Gateway\r\nContent-Length: 0\r\n\r\n');
-        tlsSocket.end();
-      });
+    mockReq.on('error', () => {
+      processing = false;
+      writeAndClose('HTTP/1.1 502 Bad Gateway\r\nContent-Length: 0\r\nConnection: close\r\n\r\n');
+    });
 
-      if (bodyBuf.length > 0) {
-        mockReq.write(bodyBuf);
-      }
-      mockReq.end();
-    };
-
-    if (contentLength > 0 && bodyStart.length < contentLength) {
-      // Need more body data
-      const remaining: Buffer[] = [bodyStart];
-      let received = bodyStart.length;
-      tlsSocket.on('data', (chunk: Buffer) => {
-        remaining.push(chunk);
-        received += chunk.length;
-        if (received >= contentLength) {
-          collectBody(Buffer.concat(remaining));
-        }
-      });
-    } else {
-      collectBody(bodyStart);
-    }
+    if (bodyBuf.length > 0) mockReq.write(bodyBuf);
+    mockReq.end();
   };
 
-  tlsSocket.on('data', onData);
-  tlsSocket.on('error', () => {});
+  tlsSocket.on('data', (chunk: Buffer) => {
+    if (closed) return;
+    buffer = Buffer.concat([buffer, chunk]);
+    tryProcessNext();
+  });
+
+  tlsSocket.on('end', () => closeSocket());
+  tlsSocket.on('close', () => {
+    closed = true;
+  });
+  tlsSocket.on('error', () => closeSocket());
 }

--- a/test/e2e/mitm-keepalive.e2e.test.ts
+++ b/test/e2e/mitm-keepalive.e2e.test.ts
@@ -1,0 +1,208 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import net from 'node:net';
+import tls from 'node:tls';
+import { readFileSync } from 'node:fs';
+import { startFwsDaemon, type CliHarness } from './helpers/cli-harness.js';
+
+/**
+ * Regression test for #7: the MITM proxy used to close the TLS socket after
+ * one response, breaking HTTP/1.1 keep-alive. Real CLIs (gh, gws) reuse
+ * connections and intermittently failed with `EOF` on the second request.
+ *
+ * This test pins the contract directly: open ONE CONNECT tunnel to the proxy,
+ * upgrade to TLS, send TWO HTTP requests over the same socket, assert both
+ * responses come back intact.
+ */
+describe('e2e: MITM proxy keep-alive (regression test for #7)', () => {
+  let h: CliHarness;
+  let caCert: string;
+
+  beforeAll(async () => {
+    h = await startFwsDaemon();
+    caCert = readFileSync(h.caPath, 'utf-8');
+  });
+
+  afterAll(async () => {
+    await h.stop();
+  });
+
+  it('handles two sequential requests on the same TLS connection', async () => {
+    const responses = await sendTwoRequestsOverOneTlsSocket(h.proxyPort, caCert, [
+      { method: 'GET', path: '/user' },
+      { method: 'GET', path: '/repos/testuser/my-project' },
+    ]);
+
+    expect(responses).toHaveLength(2);
+
+    expect(responses[0].statusCode).toBe(200);
+    const user = JSON.parse(responses[0].body);
+    expect(user.login).toBe('testuser');
+
+    expect(responses[1].statusCode).toBe(200);
+    const repo = JSON.parse(responses[1].body);
+    expect(repo.full_name).toBe('testuser/my-project');
+  });
+
+  it('handles three sequential requests on the same TLS connection', async () => {
+    const responses = await sendTwoRequestsOverOneTlsSocket(h.proxyPort, caCert, [
+      { method: 'GET', path: '/user' },
+      { method: 'GET', path: '/repos/testuser/my-project/issues' },
+      { method: 'GET', path: '/repos/testuser/my-project/pulls' },
+    ]);
+
+    expect(responses).toHaveLength(3);
+    for (const r of responses) {
+      expect(r.statusCode).toBe(200);
+    }
+    const issues = JSON.parse(responses[1].body);
+    const pulls = JSON.parse(responses[2].body);
+    expect(Array.isArray(issues)).toBe(true);
+    expect(Array.isArray(pulls)).toBe(true);
+  });
+});
+
+interface ParsedResponse {
+  statusCode: number;
+  headers: Record<string, string>;
+  body: string;
+}
+
+interface RequestSpec {
+  method: string;
+  path: string;
+  body?: string;
+}
+
+/**
+ * Open one CONNECT tunnel to the MITM proxy, upgrade to TLS against
+ * api.github.com (which the proxy intercepts), then send each request on the
+ * SAME TLS socket and parse the responses in order.
+ *
+ * Deliberately does NOT use Node's `https.Agent` — we want to drive the wire
+ * protocol directly so the test fails immediately if the proxy closes the
+ * socket prematurely.
+ */
+async function sendTwoRequestsOverOneTlsSocket(
+  proxyPort: number,
+  caCert: string,
+  requests: RequestSpec[],
+): Promise<ParsedResponse[]> {
+  // Step 1: open the CONNECT tunnel
+  const tunnel = await new Promise<net.Socket>((resolve, reject) => {
+    const sock = net.connect(proxyPort, '127.0.0.1');
+    let buf = '';
+    const onData = (chunk: Buffer) => {
+      buf += chunk.toString('utf-8');
+      const end = buf.indexOf('\r\n\r\n');
+      if (end === -1) return;
+      sock.removeListener('data', onData);
+      const statusLine = buf.split('\r\n')[0];
+      if (!/^HTTP\/1\.\d 200/.test(statusLine)) {
+        sock.destroy();
+        reject(new Error(`CONNECT failed: ${statusLine}`));
+        return;
+      }
+      resolve(sock);
+    };
+    sock.on('data', onData);
+    sock.on('error', reject);
+    sock.write('CONNECT api.github.com:443 HTTP/1.1\r\nHost: api.github.com:443\r\n\r\n');
+  });
+
+  // Step 2: TLS handshake on the tunneled socket
+  const tlsSock = await new Promise<tls.TLSSocket>((resolve, reject) => {
+    const t = tls.connect({
+      socket: tunnel,
+      servername: 'api.github.com',
+      ca: caCert,
+    });
+    t.once('secureConnect', () => resolve(t));
+    t.once('error', reject);
+  });
+
+  // Step 3: send each request and parse the response, all on the same socket.
+  // We do this serially so we can identify which response belongs to which
+  // request without dealing with HTTP pipelining ambiguity.
+  const out: ParsedResponse[] = [];
+  for (const req of requests) {
+    const reqLines = [
+      `${req.method} ${req.path} HTTP/1.1`,
+      `Host: api.github.com`,
+      `User-Agent: fws-keepalive-test`,
+      `Accept: application/json`,
+    ];
+    if (req.body !== undefined) {
+      reqLines.push(`Content-Length: ${Buffer.byteLength(req.body)}`);
+      reqLines.push(`Content-Type: application/json`);
+    }
+    reqLines.push(''); // header terminator
+    reqLines.push(req.body ?? '');
+    tlsSock.write(reqLines.join('\r\n'));
+
+    const resp = await readOneResponse(tlsSock);
+    out.push(resp);
+  }
+
+  tlsSock.end();
+  return out;
+}
+
+/** Read exactly one HTTP/1.1 response off a TLS socket. Honors Content-Length. */
+function readOneResponse(sock: tls.TLSSocket): Promise<ParsedResponse> {
+  return new Promise((resolve, reject) => {
+    let buf = Buffer.alloc(0);
+    let headerLen = -1;
+    let contentLength = -1;
+    let headers: Record<string, string> = {};
+    let statusCode = 0;
+
+    const onData = (chunk: Buffer) => {
+      buf = Buffer.concat([buf, chunk]);
+      if (headerLen === -1) {
+        const end = buf.indexOf('\r\n\r\n');
+        if (end === -1) return; // need more
+        headerLen = end + 4;
+        const headerStr = buf.subarray(0, end).toString('utf-8');
+        const [statusLine, ...lines] = headerStr.split('\r\n');
+        const m = statusLine.match(/^HTTP\/1\.\d (\d+)/);
+        if (!m) {
+          cleanup();
+          reject(new Error(`bad status line: ${statusLine}`));
+          return;
+        }
+        statusCode = parseInt(m[1]);
+        for (const line of lines) {
+          const idx = line.indexOf(':');
+          if (idx > 0) {
+            const k = line.slice(0, idx).trim().toLowerCase();
+            const v = line.slice(idx + 1).trim();
+            headers[k] = v;
+            if (k === 'content-length') contentLength = parseInt(v);
+          }
+        }
+        if (contentLength === -1) {
+          // No Content-Length: the mock always sets one (express does), so
+          // treat this as an error rather than reading until close.
+          cleanup();
+          reject(new Error('response missing Content-Length'));
+          return;
+        }
+      }
+      if (buf.length - headerLen >= contentLength) {
+        const body = buf.subarray(headerLen, headerLen + contentLength).toString('utf-8');
+        cleanup();
+        resolve({ statusCode, headers, body });
+      }
+    };
+    const onError = (err: Error) => {
+      cleanup();
+      reject(err);
+    };
+    const cleanup = () => {
+      sock.removeListener('data', onData);
+      sock.removeListener('error', onError);
+    };
+    sock.on('data', onData);
+    sock.on('error', onError);
+  });
+}


### PR DESCRIPTION
Fixes #7.

## Summary

Rewrites `src/proxy/mitm.ts` `handleInterceptedRequest` to support HTTP/1.1 keep-alive — multiple requests per CONNECT tunnel — instead of closing the TLS socket after one response.

## Why

The previous implementation read exactly one request, forwarded it, and called `tlsSocket.end()`. HTTP/1.1 defaults to keep-alive, so any client doing more than one request per host (`gh issue view` fires `issueOrPullRequest` then `projectItems` on the same connection; `gws +reply-all` and friends do similar) raced against the close and intermittently failed:

```
gh stderr: Post "https://api.github.com/graphql": EOF
```

This forced PR #6 to slim down the publish workflow's test step.

## What changed

- **Single persistent `data` listener** that buffers bytes. After each request is fully consumed, leftover bytes (start of the next request) stay in the buffer for the next pass.
- **Buffered upstream response** written as one chunk instead of `mockRes.pipe(tlsSocket)`. The upstream `end` event no longer terminates the TLS socket.
- **Socket only closes** when the client sent `Connection: close`, the upstream returned `Connection: close`, the client disconnected, or an error occurred.
- **502 error responses** now also send `Connection: close` so callers don't try to reuse a half-broken socket.

### Known limitation

Still no support for `Transfer-Encoding: chunked` on the **request** side. `gh` and `gws` both buffer requests in memory and send `Content-Length`, so this is fine in practice. Worth revisiting if a future client needs it.

## Test

New `test/e2e/mitm-keepalive.e2e.test.ts`:
- Opens **one** CONNECT tunnel to the proxy
- Upgrades to TLS against `api.github.com` (intercepted)
- Sends 2 (and separately, 3) HTTP requests on the **same** TLS socket
- Asserts each response comes back intact

Drives the wire protocol manually instead of using `https.Agent` so a regression would surface as an immediate test failure rather than as a transparent retry.

**Verified:**
- Test fails (timeout) against the old `handleInterceptedRequest` ✓
- Test passes against the new code ✓
- Full suite: 160/160 passing locally
- The previously-flaky `gh issue view 1` test ran 5 times in a row, all green

## Test plan
- [x] CI `unit` job green
- [x] CI `e2e` job green (includes the new keep-alive test)
- [ ] Confirm `gh issue view 1` and `gws gmail +reply-all` are no longer flaky on subsequent CI runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
