### PR TITLE
Add gh and gws e2e suites against real daemon

### DIFF
--- a/test/e2e/gh.e2e.test.ts
+++ b/test/e2e/gh.e2e.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { startFwsDaemon, type CliHarness } from './helpers/cli-harness.js';
+
+/**
+ * E2E coverage for the `gh` CLI against the real `fws server start` daemon
+ * (not the in-process Express harness). Mirrors test/gh-validation.test.ts
+ * but exercises the daemon path: detached spawn, on-disk certs, MITM proxy
+ * across processes.
+ */
+describe('e2e: gh CLI against real daemon', () => {
+  let h: CliHarness;
+
+  beforeAll(async () => {
+    h = await startFwsDaemon();
+  });
+
+  afterAll(async () => {
+    await h.stop();
+  });
+
+  describe('REST API (gh api)', () => {
+    it('gh api /user', async () => {
+      const { stdout, stderr, exitCode } = await h.runStr('gh', 'api /user');
+      expect(exitCode, stderr).toBe(0);
+      const data = JSON.parse(stdout);
+      expect(data.login).toBe('testuser');
+      expect(data.name).toBe('Test User');
+    });
+
+    it('gh api /repos/testuser/my-project', async () => {
+      const { stdout, stderr, exitCode } = await h.runStr('gh', 'api /repos/testuser/my-project');
+      expect(exitCode, stderr).toBe(0);
+      const data = JSON.parse(stdout);
+      expect(data.full_name).toBe('testuser/my-project');
+    });
+
+    it('gh api .../issues (list)', async () => {
+      const { stdout, stderr, exitCode } = await h.runStr('gh', 'api /repos/testuser/my-project/issues');
+      expect(exitCode, stderr).toBe(0);
+      const data = JSON.parse(stdout);
+      expect(data.length).toBeGreaterThan(0);
+      expect(data.some((i: any) => i.title === 'Fix login bug')).toBe(true);
+    });
+
+    it('gh api .../issues/1 (get)', async () => {
+      const { stdout, stderr, exitCode } = await h.runStr('gh', 'api /repos/testuser/my-project/issues/1');
+      expect(exitCode, stderr).toBe(0);
+      const data = JSON.parse(stdout);
+      expect(data.title).toBe('Fix login bug');
+      expect(data.state).toBe('open');
+    });
+
+    it('gh api .../issues (create)', async () => {
+      const { stdout, stderr, exitCode } = await h.run('gh', [
+        'api',
+        '--method', 'POST',
+        '/repos/testuser/my-project/issues',
+        '-f', 'title=e2e created issue',
+        '-f', 'body=created from gh-e2e.test.ts',
+      ]);
+      expect(exitCode, stderr).toBe(0);
+      const data = JSON.parse(stdout);
+      expect(data.title).toBe('e2e created issue');
+      expect(data.number).toBeTypeOf('number');
+    });
+
+    it('gh api .../issues/1/comments (create + list)', async () => {
+      const { stderr: cErr, exitCode: cCode } = await h.run('gh', [
+        'api',
+        '--method', 'POST',
+        '/repos/testuser/my-project/issues/1/comments',
+        '-f', 'body=e2e comment',
+      ]);
+      expect(cCode, cErr).toBe(0);
+
+      const { stdout, stderr, exitCode } = await h.runStr('gh', 'api /repos/testuser/my-project/issues/1/comments');
+      expect(exitCode, stderr).toBe(0);
+      const data = JSON.parse(stdout);
+      expect(Array.isArray(data)).toBe(true);
+      expect(data.some((c: any) => c.body === 'e2e comment')).toBe(true);
+    });
+
+    it('gh api .../pulls (list)', async () => {
+      const { stdout, stderr, exitCode } = await h.runStr('gh', 'api /repos/testuser/my-project/pulls');
+      expect(exitCode, stderr).toBe(0);
+      const data = JSON.parse(stdout);
+      expect(data.length).toBeGreaterThan(0);
+    });
+
+    it('gh api .../pulls/3 (get)', async () => {
+      const { stdout, stderr, exitCode } = await h.runStr('gh', 'api /repos/testuser/my-project/pulls/3');
+      expect(exitCode, stderr).toBe(0);
+      const data = JSON.parse(stdout);
+      expect(data.number).toBe(3);
+    });
+
+    it('gh api /search/issues', async () => {
+      const { stdout, stderr, exitCode } = await h.runStr('gh', 'api /search/issues?q=fix');
+      expect(exitCode, stderr).toBe(0);
+      const data = JSON.parse(stdout);
+      expect(data.total_count).toBeTypeOf('number');
+    });
+
+    it('gh api PATCH issue close', async () => {
+      const { stdout, stderr, exitCode } = await h.run('gh', [
+        'api',
+        '--method', 'PATCH',
+        '/repos/testuser/my-project/issues/2',
+        '-f', 'state=closed',
+      ]);
+      expect(exitCode, stderr).toBe(0);
+      const data = JSON.parse(stdout);
+      expect(data.state).toBe('closed');
+    });
+  });
+
+  describe('GraphQL (gh issue / pr commands)', () => {
+    it('gh issue list', async () => {
+      const { stdout, stderr, exitCode } = await h.runStr('gh', 'issue list');
+      expect(exitCode, stderr).toBe(0);
+      expect(stdout).toContain('Fix login bug');
+    });
+
+    it('gh issue view 1', async () => {
+      // Regression smoke for #7 (MITM keep-alive). gh issue view fires two
+      // GraphQL requests on the same TLS connection.
+      const { stdout, stderr, exitCode } = await h.runStr('gh', 'issue view 1');
+      expect(exitCode, `gh stderr: ${stderr}`).toBe(0);
+      expect(stdout).toContain('Fix login bug');
+      expect(stdout).toContain('OPEN');
+    });
+
+    it('gh pr list', async () => {
+      const { stdout, stderr, exitCode } = await h.runStr('gh', 'pr list');
+      expect(exitCode, stderr).toBe(0);
+      expect(stdout).toContain('Fix SSO login flow');
+    });
+
+    it('gh pr view 3', async () => {
+      const { stdout, stderr, exitCode } = await h.runStr('gh', 'pr view 3');
+      expect(exitCode, `gh stderr: ${stderr}`).toBe(0);
+      expect(stdout).toContain('Fix SSO login flow');
+      expect(stdout).toContain('OPEN');
+    });
+
+    it('gh issue list --json', async () => {
+      const { stdout, stderr, exitCode } = await h.run('gh', [
+        'issue', 'list', '--json', 'number,title,state',
+      ]);
+      expect(exitCode, stderr).toBe(0);
+      const data = JSON.parse(stdout);
+      expect(Array.isArray(data)).toBe(true);
+      expect(data.length).toBeGreaterThan(0);
+      expect(data[0]).toHaveProperty('number');
+      expect(data[0]).toHaveProperty('title');
+    });
+  });
+});

--- a/test/e2e/gws.e2e.test.ts
+++ b/test/e2e/gws.e2e.test.ts
@@ -1,0 +1,267 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { startFwsDaemon, type CliHarness } from './helpers/cli-harness.js';
+
+/**
+ * E2E coverage for the `gws` (Google Workspace) CLI against the real
+ * `fws server start` daemon. Mirrors the structure of test/gws-validation.test.ts
+ * but talks to a real daemon instead of an in-process Express app, so it
+ * exercises:
+ *
+ *  - the discovery cache rewritten on disk by `fws server start`
+ *  - the MITM proxy across processes (helpers like +triage / +send /
+ *    +reply / +forward go via HTTPS_PROXY)
+ *  - keep-alive across multiple requests per host (regression: #7)
+ *
+ * The coverage is intentionally broad rather than exhaustive: one or two
+ * representative commands per resource is enough to catch daemon-mode
+ * regressions, since the in-process suite already covers each command's
+ * surface in detail.
+ */
+describe('e2e: gws CLI against real daemon', () => {
+  let h: CliHarness;
+
+  beforeAll(async () => {
+    h = await startFwsDaemon();
+  });
+
+  afterAll(async () => {
+    await h.stop();
+  });
+
+  // ===== Gmail =====
+
+  describe('gmail', () => {
+    it('users getProfile', async () => {
+      const { stdout, stderr, exitCode } = await h.runStr(
+        'gws', 'gmail users getProfile --params {"userId":"me"}',
+      );
+      expect(exitCode, stderr).toBe(0);
+      const data = JSON.parse(stdout);
+      expect(data.emailAddress).toBe('testuser@example.com');
+    });
+
+    it('users labels list', async () => {
+      const { stdout, stderr, exitCode } = await h.runStr(
+        'gws', 'gmail users labels list --params {"userId":"me"}',
+      );
+      expect(exitCode, stderr).toBe(0);
+      const data = JSON.parse(stdout);
+      expect(data.labels.map((l: any) => l.id)).toContain('INBOX');
+    });
+
+    it('users labels create + delete', async () => {
+      const { stdout, stderr, exitCode } = await h.runStr(
+        'gws', 'gmail users labels create --params {"userId":"me"} --json {"name":"E2eLabel"}',
+      );
+      expect(exitCode, stderr).toBe(0);
+      const created = JSON.parse(stdout);
+      expect(created.name).toBe('E2eLabel');
+
+      const del = await h.runStr(
+        'gws', `gmail users labels delete --params {"userId":"me","id":"${created.id}"}`,
+      );
+      expect(del.exitCode, del.stderr).toBe(0);
+    });
+
+    it('users messages list', async () => {
+      const { stdout, stderr, exitCode } = await h.runStr(
+        'gws', 'gmail users messages list --params {"userId":"me"}',
+      );
+      expect(exitCode, stderr).toBe(0);
+      const data = JSON.parse(stdout);
+      expect(Array.isArray(data.messages)).toBe(true);
+      expect(data.messages.length).toBeGreaterThan(0);
+    });
+
+    it('users messages get', async () => {
+      const { stdout, stderr, exitCode } = await h.runStr(
+        'gws', 'gmail users messages get --params {"userId":"me","id":"msg001"}',
+      );
+      expect(exitCode, stderr).toBe(0);
+      const data = JSON.parse(stdout);
+      expect(data.id).toBe('msg001');
+      expect(data.payload.headers.some((h: any) => h.name === 'Subject')).toBe(true);
+    });
+
+    it('users threads list', async () => {
+      const { stdout, stderr, exitCode } = await h.runStr(
+        'gws', 'gmail users threads list --params {"userId":"me"}',
+      );
+      expect(exitCode, stderr).toBe(0);
+      const data = JSON.parse(stdout);
+      expect(Array.isArray(data.threads)).toBe(true);
+    });
+
+    // ===== Helpers (multipart upload path — was the gws 0.16 → 0.22 break) =====
+
+    describe('helpers', () => {
+      it('+triage', async () => {
+        const { stdout, stderr, exitCode } = await h.runStr(
+          'gws', 'gmail +triage --max 3 --format json',
+        );
+        expect(exitCode, stderr).toBe(0);
+        const data = JSON.parse(stdout);
+        expect(data.messages.length).toBeGreaterThan(0);
+        expect(data.messages[0]).toHaveProperty('subject');
+      });
+
+      it('+send', async () => {
+        const { stdout, stderr, exitCode } = await h.runStr(
+          'gws', 'gmail +send --to bob@example.com --subject "E2E send" --body "Hello from e2e"',
+        );
+        expect(exitCode, stderr).toBe(0);
+        const data = JSON.parse(stdout);
+        expect(data.id).toBeTruthy();
+        expect(data.labelIds).toContain('SENT');
+      });
+
+      it('+reply', async () => {
+        const { stdout, stderr, exitCode } = await h.runStr(
+          'gws', 'gmail +reply --message-id msg001 --body "E2E reply"',
+        );
+        expect(exitCode, stderr).toBe(0);
+        const data = JSON.parse(stdout);
+        expect(data.id).toBeTruthy();
+        expect(data.threadId).toBe('thread001');
+      });
+
+      it('+reply-all', async () => {
+        const { stdout, stderr, exitCode } = await h.runStr(
+          'gws', 'gmail +reply-all --message-id msg001 --body "E2E reply-all"',
+        );
+        expect(exitCode, stderr).toBe(0);
+        const data = JSON.parse(stdout);
+        expect(data.threadId).toBe('thread001');
+      });
+
+      it('+forward', async () => {
+        const { stdout, stderr, exitCode } = await h.runStr(
+          'gws', 'gmail +forward --message-id msg001 --to carol@example.com --body "E2E fwd"',
+        );
+        expect(exitCode, stderr).toBe(0);
+        const data = JSON.parse(stdout);
+        expect(data.threadId).toBe('thread001');
+      });
+    });
+  });
+
+  // ===== Calendar =====
+
+  describe('calendar', () => {
+    it('calendarList list', async () => {
+      const { stdout, stderr, exitCode } = await h.runStr('gws', 'calendar calendarList list');
+      expect(exitCode, stderr).toBe(0);
+      const data = JSON.parse(stdout);
+      expect(data.items.length).toBeGreaterThan(0);
+      expect(data.items.some((c: any) => c.primary)).toBe(true);
+    });
+
+    it('events list', async () => {
+      const { stdout, stderr, exitCode } = await h.runStr(
+        'gws', 'calendar events list --params {"calendarId":"primary"}',
+      );
+      expect(exitCode, stderr).toBe(0);
+      const data = JSON.parse(stdout);
+      expect(Array.isArray(data.items)).toBe(true);
+    });
+
+    it('events insert', async () => {
+      const { stdout, stderr, exitCode } = await h.runStr(
+        'gws',
+        'calendar events insert --params {"calendarId":"primary"} --json {"summary":"E2E meeting","start":{"dateTime":"2026-05-01T10:00:00Z"},"end":{"dateTime":"2026-05-01T11:00:00Z"}}',
+      );
+      expect(exitCode, stderr).toBe(0);
+      const data = JSON.parse(stdout);
+      expect(data.summary).toBe('E2E meeting');
+      expect(data.id).toBeTruthy();
+    });
+  });
+
+  // ===== Drive =====
+
+  describe('drive', () => {
+    it('files list', async () => {
+      const { stdout, stderr, exitCode } = await h.runStr('gws', 'drive files list');
+      expect(exitCode, stderr).toBe(0);
+      const data = JSON.parse(stdout);
+      expect(Array.isArray(data.files)).toBe(true);
+      expect(data.files.length).toBeGreaterThan(0);
+    });
+
+    it('files get', async () => {
+      const list = await h.runStr('gws', 'drive files list');
+      const fileId = JSON.parse(list.stdout).files[0].id;
+
+      const { stdout, stderr, exitCode } = await h.runStr(
+        'gws', `drive files get --params {"fileId":"${fileId}"}`,
+      );
+      expect(exitCode, stderr).toBe(0);
+      const data = JSON.parse(stdout);
+      expect(data.id).toBe(fileId);
+    });
+
+    it('about get', async () => {
+      const { stdout, stderr, exitCode } = await h.runStr(
+        'gws', 'drive about get --params {"fields":"user,storageQuota"}',
+      );
+      expect(exitCode, stderr).toBe(0);
+      const data = JSON.parse(stdout);
+      expect(data.user).toBeTruthy();
+    });
+  });
+
+  // ===== Tasks =====
+
+  describe('tasks', () => {
+    it('tasklists list', async () => {
+      const { stdout, stderr, exitCode } = await h.runStr('gws', 'tasks tasklists list');
+      expect(exitCode, stderr).toBe(0);
+      const data = JSON.parse(stdout);
+      expect(data.items.length).toBeGreaterThan(0);
+    });
+
+    it('tasks list', async () => {
+      const { stdout, stderr, exitCode } = await h.runStr(
+        'gws', 'tasks tasks list --params {"tasklist":"default"}',
+      );
+      expect(exitCode, stderr).toBe(0);
+      const data = JSON.parse(stdout);
+      expect(Array.isArray(data.items)).toBe(true);
+    });
+  });
+
+  // ===== Sheets =====
+
+  describe('sheets', () => {
+    it('spreadsheets get', async () => {
+      const { stdout, stderr, exitCode } = await h.runStr(
+        'gws', 'sheets spreadsheets get --params {"spreadsheetId":"sheet001"}',
+      );
+      expect(exitCode, stderr).toBe(0);
+      const data = JSON.parse(stdout);
+      expect(data.spreadsheetId).toBe('sheet001');
+      expect(data.properties.title).toBe('Budget 2026');
+    });
+  });
+
+  // ===== People =====
+
+  describe('people', () => {
+    it('people connections list', async () => {
+      const { stdout, stderr, exitCode } = await h.runStr(
+        'gws',
+        'people people connections list --params {"resourceName":"people/me","personFields":"names,emailAddresses"}',
+      );
+      expect(exitCode, stderr).toBe(0);
+      const data = JSON.parse(stdout);
+      expect(Array.isArray(data.connections)).toBe(true);
+    });
+
+    it('contactGroups list', async () => {
+      const { stdout, stderr, exitCode } = await h.runStr('gws', 'people contactGroups list');
+      expect(exitCode, stderr).toBe(0);
+      const data = JSON.parse(stdout);
+      expect(Array.isArray(data.contactGroups)).toBe(true);
+    });
+  });
+});

--- a/test/e2e/helpers/cli-harness.ts
+++ b/test/e2e/helpers/cli-harness.ts
@@ -34,6 +34,17 @@ export interface CliHarness {
     args: string[],
     extraEnv?: Record<string, string>,
   ) => Promise<{ stdout: string; stderr: string; exitCode: number }>;
+  /**
+   * Convenience for invoking gws / gh with a single string of args.
+   * Splits on whitespace but keeps JSON objects (`{...}`) and quoted strings
+   * as one argument. Mirrors the existing `harness.ts` syntax so e2e tests
+   * read the same as the in-process tests.
+   */
+  runStr: (
+    bin: string,
+    argsString: string,
+    extraEnv?: Record<string, string>,
+  ) => Promise<{ stdout: string; stderr: string; exitCode: number }>;
   /** Direct fetch against the mock server (no proxy) */
   fetch: (urlPath: string, init?: RequestInit) => Promise<Response>;
   /** Stop the daemon and clean up tmp dirs */
@@ -78,6 +89,40 @@ function runCmd(
       });
     });
   });
+}
+
+/**
+ * Split a single args string into argv. Mirrors the parser used in
+ * test/helpers/harness.ts so e2e and in-process tests stay readable in the
+ * same syntax. Keeps JSON objects (`{...}`) and quoted strings as one arg.
+ */
+function parseArgs(args: string): string[] {
+  const result: string[] = [];
+  let current = '';
+  let braceDepth = 0;
+  let inQuote: string | null = null;
+  for (const char of args) {
+    if (!inQuote && !braceDepth && (char === '"' || char === "'")) {
+      inQuote = char;
+      continue;
+    }
+    if (inQuote && char === inQuote) {
+      inQuote = null;
+      continue;
+    }
+    if (!inQuote) {
+      if (char === '{') braceDepth++;
+      if (char === '}') braceDepth--;
+    }
+    if (char === ' ' && braceDepth === 0 && !inQuote) {
+      if (current) result.push(current);
+      current = '';
+    } else {
+      current += char;
+    }
+  }
+  if (current) result.push(current);
+  return result;
 }
 
 async function waitForHealth(port: number, timeoutMs = 8000): Promise<void> {
@@ -161,6 +206,8 @@ export async function startFwsDaemon(opts: StartOptions = {}): Promise<CliHarnes
     fetch: (urlPath, init) => globalThis.fetch(`http://localhost:${info.port}${urlPath}`, init),
     run: (bin, args, extraEnv = {}) =>
       runCmd(bin, args, { ...process.env, ...proxyEnv, ...extraEnv }),
+    runStr: (bin, argsString, extraEnv = {}) =>
+      runCmd(bin, parseArgs(argsString), { ...process.env, ...proxyEnv, ...extraEnv }),
     stop: async () => {
       // Use the real CLI so we exercise the stop path too
       await runCmd('node', [fwsBin, 'server', 'stop'], env, 5000);


### PR DESCRIPTION
Closes #9.

> ⚠️ **Depends on #8** (MITM keep-alive fix). The new gh GraphQL tests fire two requests on the same TLS connection — without #8 they will flake. Merge #8 first, then rebase this onto main if needed.

## Summary

Adds two dedicated e2e suites that exercise every supported CLI against the real `fws server start` daemon:

- **`test/e2e/gh.e2e.test.ts`** — 15 tests covering `gh api` (REST), `gh issue / pr list / view` (GraphQL)
- **`test/e2e/gws.e2e.test.ts`** — 22 tests covering one or two representative commands per resource (gmail, calendar, drive, tasks, sheets, people) plus all 5 gmail helpers (`+triage / +send / +reply / +reply-all / +forward`)

Plus a small DX helper:

- **`test/e2e/helpers/cli-harness.ts`** — new `runStr(bin, argString)` so e2e tests can use the same single-string args syntax as the in-process tests in `test/helpers/harness.ts`. The same parser handles JSON braces and quoted strings as one argument, so `gws gmail users labels create --params {"userId":"me"} --json {"name":"E2eLabel"}` Just Works.

## Why this matters

The in-process `test/gh-validation.test.ts` and `test/gws-validation.test.ts` already exercise each command's response shape in detail against an in-process Express harness. They don't catch bugs in the daemon path: detached spawn, on-disk cert generation, MITM proxy across processes, discovery cache written to a real `FWS_DATA_DIR`, port allocation, server.json handling.

These new e2e suites talk to the real daemon, so they catch regressions in any of those layers. Coverage is intentionally **broad rather than exhaustive** — the in-process suites already give per-command depth, so the e2e tests just need one or two representative commands per resource to validate the daemon mode.

## Counts

|  | before | after |
|---|---|---|
| unit | 150 | 150 |
| e2e | 8 | **45** |
| **total** | 158 | **197** |

All 197 pass locally. e2e suite runtime is ~10s total (one daemon per test file, reused across tests).

## Notes for review

- The gws e2e tests don't try to mirror every one of the 89 cases in `gws-validation.test.ts` — that would duplicate ~1000 lines for marginal value, since the in-process suite already validates command shapes. The e2e file picks the commands most likely to expose daemon-mode bugs (helpers via multipart upload, paginated listings, JSON-param mutation calls).
- The gh GraphQL tests (`gh issue view 1` etc.) are deliberately included as ongoing regression smoke for the MITM keep-alive fix in #8 — those were the canary failures that originally exposed the bug.
- Same `*.e2e.test.ts` filename suffix as the existing e2e files so vitest's `e2e` project picks them up automatically (no config change needed).

## Test plan
- [ ] CI `unit` job green
- [ ] CI `e2e` job green (now includes gh.e2e.test.ts and gws.e2e.test.ts)
- [ ] No flake on `gh issue view 1` or `gws gmail +reply-all` after this lands

## Followups

- Per #9 description: a `curl-e2e.test.ts` should land alongside the Web Fetch fake service (#2). Not included here since the curl coverage in `cli-through-proxy.e2e.test.ts` already smokes the proxy.
- A future refactor could share test bodies between the in-process and e2e suites by parameterizing the harness, but that's a larger change and not blocking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
