### PR TITLE
Add Search fake web service (Google Custom Search API mock) + e2e

### DIFF
--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -6,6 +6,7 @@ import { tasksRoutes } from './routes/tasks.js';
 import { sheetsRoutes } from './routes/sheets.js';
 import { peopleRoutes } from './routes/people.js';
 import { githubRoutes } from './routes/github.js';
+import { searchRoutes } from './routes/search.js';
 import { controlRoutes } from './routes/control.js';
 import { errorHandler } from './middleware.js';
 
@@ -21,6 +22,7 @@ export function createApp(): express.Express {
   app.use(sheetsRoutes());
   app.use(peopleRoutes());
   app.use(githubRoutes());
+  app.use(searchRoutes());
 
   app.use(errorHandler);
 

--- a/src/server/routes/search.ts
+++ b/src/server/routes/search.ts
@@ -1,0 +1,125 @@
+import { Router } from 'express';
+import { getStore } from '../../store/index.js';
+import type { SearchResult } from '../../store/types.js';
+
+/**
+ * Mocks the Google Custom Search JSON API.
+ * https://developers.google.com/custom-search/v1/reference/rest/v1/cse/list
+ *
+ * Endpoint: GET /customsearch/v1?q=...&cx=...&num=...&start=...
+ * Routed via the MITM proxy because `www.googleapis.com` is intercepted.
+ */
+export function searchRoutes(): Router {
+  const r = Router();
+
+  r.get('/customsearch/v1', (req, res) => {
+    const q = String(req.query.q ?? '');
+    const cx = String(req.query.cx ?? 'fws-default-cx');
+    const num = clamp(parseInt(String(req.query.num ?? '10')) || 10, 1, 10);
+    const start = Math.max(1, parseInt(String(req.query.start ?? '1')) || 1);
+
+    if (!q) {
+      return res.status(400).json({
+        error: {
+          code: 400,
+          message: "Required parameter: q",
+          errors: [{ message: 'Required parameter: q', domain: 'global', reason: 'required' }],
+        },
+      });
+    }
+
+    const all = matchResults(q);
+    const total = all.length;
+    const items = all.slice(start - 1, start - 1 + num);
+
+    const t0 = Date.now();
+    const searchTime = (Date.now() - t0) / 1000 + 0.05;
+
+    const queriesRequest = [{
+      title: 'Google Custom Search - ' + q,
+      totalResults: String(total),
+      searchTerms: q,
+      count: items.length,
+      startIndex: start,
+      inputEncoding: 'utf8',
+      outputEncoding: 'utf8',
+      safe: 'off',
+      cx,
+    }];
+
+    const response: any = {
+      kind: 'customsearch#search',
+      url: {
+        type: 'application/json',
+        template:
+          'https://www.googleapis.com/customsearch/v1?q={searchTerms}&num={count?}&start={startIndex?}&cx={cx?}',
+      },
+      queries: { request: queriesRequest } as any,
+      context: { title: 'fws mock search' },
+      searchInformation: {
+        searchTime,
+        formattedSearchTime: searchTime.toFixed(2),
+        totalResults: String(total),
+        formattedTotalResults: String(total),
+      },
+      items: items.map(formatItem),
+    };
+
+    if (start - 1 + num < total) {
+      (response.queries as any).nextPage = [{
+        ...queriesRequest[0],
+        startIndex: start + num,
+      }];
+    }
+    if (start > 1) {
+      (response.queries as any).previousPage = [{
+        ...queriesRequest[0],
+        startIndex: Math.max(1, start - num),
+      }];
+    }
+
+    res.json(response);
+  });
+
+  // Setup helper: add a search fixture at runtime
+  r.post('/__fws/setup/search/fixture', (req, res) => {
+    const store = getStore();
+    const { keywords, results } = req.body || {};
+    if (!Array.isArray(keywords) || !Array.isArray(results)) {
+      return res.status(400).json({ error: 'keywords and results arrays required' });
+    }
+    store.search.fixtures.push({ keywords, results });
+    res.json({ status: 'added', count: store.search.fixtures.length });
+  });
+
+  return r;
+}
+
+function matchResults(query: string): SearchResult[] {
+  const store = getStore();
+  const lower = query.toLowerCase();
+  for (const fix of store.search.fixtures) {
+    if (fix.keywords.some(k => lower.includes(k.toLowerCase()))) {
+      return fix.results;
+    }
+  }
+  return store.search.defaultResults;
+}
+
+function formatItem(r: SearchResult) {
+  return {
+    kind: 'customsearch#result',
+    title: r.title,
+    htmlTitle: r.title,
+    link: r.link,
+    displayLink: r.displayLink,
+    snippet: r.snippet,
+    htmlSnippet: r.snippet,
+    formattedUrl: r.link,
+    htmlFormattedUrl: r.link,
+  };
+}
+
+function clamp(n: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, n));
+}

--- a/src/store/seed.ts
+++ b/src/store/seed.ts
@@ -1,4 +1,4 @@
-import type { FwsStore, GmailLabel, GmailMessage, CalendarEvent, DriveFile, TaskList, Task, Spreadsheet, Person, ContactGroup, GitHubStore } from './types.js';
+import type { FwsStore, GmailLabel, GmailMessage, CalendarEvent, DriveFile, TaskList, Task, Spreadsheet, Person, ContactGroup, GitHubStore, SearchStore } from './types.js';
 import { generateEtag } from '../util/id.js';
 
 const SYSTEM_LABELS: GmailLabel[] = [
@@ -409,6 +409,61 @@ export function createSeedStore(): FwsStore {
         ],
       },
     },
+    search: createSearchSeed(),
+  };
+}
+
+function createSearchSeed(): SearchStore {
+  return {
+    fixtures: [
+      {
+        keywords: ['typescript', 'ts'],
+        results: [
+          {
+            title: 'TypeScript: JavaScript With Syntax For Types',
+            link: 'https://www.typescriptlang.org/',
+            displayLink: 'www.typescriptlang.org',
+            snippet: 'TypeScript extends JavaScript by adding types to the language.',
+          },
+          {
+            title: 'TypeScript Documentation',
+            link: 'https://www.typescriptlang.org/docs/',
+            displayLink: 'www.typescriptlang.org',
+            snippet: 'Find TypeScript starter projects: from Angular to React or Node.js and CLIs.',
+          },
+        ],
+      },
+      {
+        keywords: ['python'],
+        results: [
+          {
+            title: 'Welcome to Python.org',
+            link: 'https://www.python.org/',
+            displayLink: 'www.python.org',
+            snippet: 'The official home of the Python Programming Language.',
+          },
+        ],
+      },
+      {
+        keywords: ['weather'],
+        results: [
+          {
+            title: 'Weather Forecast - Example.com',
+            link: 'https://weather.example.com/',
+            displayLink: 'weather.example.com',
+            snippet: 'Today: sunny, high 72°F. Tomorrow: partly cloudy.',
+          },
+        ],
+      },
+    ],
+    defaultResults: [
+      {
+        title: 'Example Domain',
+        link: 'https://example.com/',
+        displayLink: 'example.com',
+        snippet: 'This domain is for use in illustrative examples in documents.',
+      },
+    ],
   };
 }
 

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -8,6 +8,7 @@ export interface FwsStore {
   sheets: SheetsStore;
   people: PeopleStore;
   github: GitHubStore;
+  search: SearchStore;
 }
 
 // === Gmail ===
@@ -305,4 +306,26 @@ export interface GitHubComment {
   created_at: string;
   updated_at: string;
   html_url: string;
+}
+
+// === Search ===
+
+export interface SearchStore {
+  /** Fixtures matched against query terms (case-insensitive substring on any keyword) */
+  fixtures: SearchFixture[];
+  /** Returned when no fixture matches */
+  defaultResults: SearchResult[];
+}
+
+export interface SearchFixture {
+  /** Keywords to look for in the query (case-insensitive). Match if ANY keyword appears. */
+  keywords: string[];
+  results: SearchResult[];
+}
+
+export interface SearchResult {
+  title: string;
+  link: string;
+  displayLink: string;
+  snippet: string;
 }

--- a/test/e2e/search.e2e.test.ts
+++ b/test/e2e/search.e2e.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { startFwsDaemon, type CliHarness } from './helpers/cli-harness.js';
+
+/**
+ * E2E coverage for the Search fake service against the real
+ * `fws server start` daemon.
+ *
+ * Two paths are exercised:
+ *  1. Direct HTTP to the daemon's `/customsearch/v1` route — confirms the
+ *     route is wired into the daemon's Express app and the seed data is
+ *     reachable.
+ *  2. `curl` against `https://www.googleapis.com/customsearch/v1` through
+ *     the MITM proxy — confirms the proxy intercepts `www.googleapis.com`
+ *     traffic and forwards it to the local route. This is the path real
+ *     callers (Google API client libraries, custom search-cse SDK, anything
+ *     that uses HTTPS_PROXY) actually take.
+ */
+describe('e2e: Search fake service against real daemon', () => {
+  let h: CliHarness;
+
+  beforeAll(async () => {
+    h = await startFwsDaemon();
+  });
+
+  afterAll(async () => {
+    await h.stop();
+  });
+
+  // ===== Direct HTTP to the daemon =====
+
+  describe('direct HTTP', () => {
+    it('returns 400 when q is missing', async () => {
+      const res = await h.fetch('/customsearch/v1?cx=abc');
+      expect(res.status).toBe(400);
+    });
+
+    it('returns fixture results for matching keyword', async () => {
+      const res = await h.fetch('/customsearch/v1?q=learn+typescript&cx=abc');
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.kind).toBe('customsearch#search');
+      expect(data.items.length).toBeGreaterThan(0);
+      expect(data.items[0].link).toContain('typescriptlang.org');
+    });
+
+    it('falls back to default results when no keyword matches', async () => {
+      const res = await h.fetch('/customsearch/v1?q=zzz_no_match_xyz&cx=abc');
+      const data = await res.json();
+      expect(data.items[0].displayLink).toBe('example.com');
+    });
+
+    it('respects num + start pagination', async () => {
+      const r1 = await h.fetch('/customsearch/v1?q=typescript&cx=abc&num=1&start=1');
+      const r2 = await h.fetch('/customsearch/v1?q=typescript&cx=abc&num=1&start=2');
+      const d1 = await r1.json();
+      const d2 = await r2.json();
+      expect(d1.items[0].link).not.toBe(d2.items[0].link);
+    });
+
+    it('accepts a runtime fixture via setup endpoint', async () => {
+      const setup = await h.fetch('/__fws/setup/search/fixture', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          keywords: ['e2emagic'],
+          results: [
+            {
+              title: 'E2E Magic',
+              link: 'https://e2e.magic.test/',
+              displayLink: 'e2e.magic.test',
+              snippet: 'e2e injected fixture',
+            },
+          ],
+        }),
+      });
+      expect(setup.status).toBe(200);
+
+      const res = await h.fetch('/customsearch/v1?q=e2emagic&cx=abc');
+      const data = await res.json();
+      expect(data.items[0].link).toBe('https://e2e.magic.test/');
+    });
+  });
+
+  // ===== Through the MITM proxy (real client path) =====
+
+  describe('through MITM proxy', () => {
+    it('curl reaches the route via https://www.googleapis.com', async () => {
+      // www.googleapis.com is in the proxy's intercept list, so this curl
+      // gets routed to the local /customsearch/v1 handler instead of the
+      // real Google API.
+      const { stdout, stderr, exitCode } = await h.run('curl', [
+        '-sf',
+        '--proxy', `http://localhost:${h.proxyPort}`,
+        '--cacert', h.caPath,
+        'https://www.googleapis.com/customsearch/v1?q=python&cx=abc',
+      ]);
+      expect(exitCode, `curl stderr: ${stderr}`).toBe(0);
+      const data = JSON.parse(stdout);
+      expect(data.kind).toBe('customsearch#search');
+      expect(data.items[0].displayLink).toBe('www.python.org');
+    });
+
+    it('multiple curl requests reuse the proxy correctly', async () => {
+      // Two separate curl invocations — each opens its own CONNECT tunnel,
+      // so this is more of a smoke test than a keep-alive check (which
+      // mitm-keepalive.e2e.test.ts already covers explicitly).
+      const queries = ['typescript', 'python', 'weather'];
+      for (const q of queries) {
+        const { stdout, exitCode } = await h.run('curl', [
+          '-sf',
+          '--proxy', `http://localhost:${h.proxyPort}`,
+          '--cacert', h.caPath,
+          `https://www.googleapis.com/customsearch/v1?q=${q}&cx=abc`,
+        ]);
+        expect(exitCode).toBe(0);
+        const data = JSON.parse(stdout);
+        expect(data.items.length).toBeGreaterThan(0);
+      }
+    });
+
+    it('returns 400 through the proxy for missing q', async () => {
+      // curl -f makes 4xx exit non-zero, so use plain curl and inspect status
+      const { stdout, exitCode } = await h.run('curl', [
+        '-s',
+        '-o', '/dev/null',
+        '-w', '%{http_code}',
+        '--proxy', `http://localhost:${h.proxyPort}`,
+        '--cacert', h.caPath,
+        'https://www.googleapis.com/customsearch/v1?cx=abc',
+      ]);
+      expect(exitCode).toBe(0);
+      expect(stdout.trim()).toBe('400');
+    });
+  });
+});

--- a/test/search.test.ts
+++ b/test/search.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { createTestHarness, type TestHarness } from './helpers/harness.js';
+
+describe('Search (Custom Search JSON API mock)', () => {
+  let h: TestHarness;
+
+  beforeAll(async () => {
+    h = await createTestHarness();
+  });
+
+  afterAll(async () => {
+    await h.cleanup();
+  });
+
+  it('returns 400 when q is missing', async () => {
+    const res = await h.fetch('/customsearch/v1?cx=abc');
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error.message).toMatch(/q/);
+  });
+
+  it('returns fixture results for matching keyword', async () => {
+    const res = await h.fetch('/customsearch/v1?q=learn+typescript&cx=abc');
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.kind).toBe('customsearch#search');
+    expect(data.items.length).toBeGreaterThan(0);
+    expect(data.items[0].link).toContain('typescriptlang.org');
+    expect(data.items[0].kind).toBe('customsearch#result');
+    expect(data.searchInformation.totalResults).toBe(String(data.items.length));
+    expect(data.queries.request[0].searchTerms).toBe('learn typescript');
+  });
+
+  it('matches case-insensitively', async () => {
+    const res = await h.fetch('/customsearch/v1?q=PYTHON+tutorial&cx=abc');
+    const data = await res.json();
+    expect(data.items[0].displayLink).toBe('www.python.org');
+  });
+
+  it('falls back to default results when no keyword matches', async () => {
+    const res = await h.fetch('/customsearch/v1?q=zzz_no_match_xyz&cx=abc');
+    const data = await res.json();
+    expect(data.items.length).toBeGreaterThan(0);
+    expect(data.items[0].displayLink).toBe('example.com');
+  });
+
+  it('respects num parameter', async () => {
+    const res = await h.fetch('/customsearch/v1?q=typescript&cx=abc&num=1');
+    const data = await res.json();
+    expect(data.items.length).toBe(1);
+    expect(data.queries.request[0].count).toBe(1);
+  });
+
+  it('respects start parameter for pagination', async () => {
+    const res1 = await h.fetch('/customsearch/v1?q=typescript&cx=abc&num=1&start=1');
+    const res2 = await h.fetch('/customsearch/v1?q=typescript&cx=abc&num=1&start=2');
+    const d1 = await res1.json();
+    const d2 = await res2.json();
+    expect(d1.items[0].link).not.toBe(d2.items[0].link);
+    expect(d1.queries.nextPage[0].startIndex).toBe(2);
+    expect(d2.queries.previousPage[0].startIndex).toBe(1);
+  });
+
+  it('accepts a runtime fixture via setup endpoint', async () => {
+    const setupRes = await h.fetch('/__fws/setup/search/fixture', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        keywords: ['fwsmagic'],
+        results: [{
+          title: 'Magic',
+          link: 'https://magic.test/',
+          displayLink: 'magic.test',
+          snippet: 'fws magic snippet',
+        }],
+      }),
+    });
+    expect(setupRes.status).toBe(200);
+
+    const res = await h.fetch('/customsearch/v1?q=fwsmagic&cx=abc');
+    const data = await res.json();
+    expect(data.items[0].link).toBe('https://magic.test/');
+    expect(data.items[0].snippet).toBe('fws magic snippet');
+  });
+});


### PR DESCRIPTION
## Summary

Adds the **Search** fake web service — a mock of the Google Custom Search JSON API at `/customsearch/v1`, plus full e2e coverage against the real `fws server start` daemon.

This is the smallest of the planned new fake services and is closing the loop on the search work that was originally on a stale branch.

## What's in the PR

### Mock service (originally landed locally as a single commit)

- **`src/server/routes/search.ts`** — `GET /customsearch/v1?q=...&cx=...&num=...&start=...` returns a Google Custom Search JSON API-shaped response. Looks up fixtures by case-insensitive substring match against the query, falls back to a default if no fixture matches. Includes `nextPage` / `previousPage` pagination metadata.
- **`POST /__fws/setup/search/fixture`** — runtime fixture-injection control endpoint so tests / users can add `{keywords, results}` pairs without restarting the daemon.
- **Store types** (`SearchStore`, `SearchFixture`, `SearchResult`) wired into the seed with example fixtures for `typescript`, `python`, `weather`, plus a default fallback.
- Routes through the MITM proxy automatically — `www.googleapis.com` is already in the intercept list, so any client that hits `https://www.googleapis.com/customsearch/v1` gets the mock for free.

### Tests

- **`test/search.test.ts`** (in-process, 7 tests) — original unit tests against the Express app: 400 on missing q, fixture matching, case-insensitive lookup, default fallback, num/start pagination, runtime fixture injection.
- **`test/e2e/search.e2e.test.ts`** (real daemon, 8 tests) — added in this PR. Two paths:
  1. Direct HTTP via `h.fetch()` against the daemon's `/customsearch/v1` route. Validates the daemon serves it across process boundaries.
  2. `curl --proxy --cacert ... https://www.googleapis.com/customsearch/v1` through the MITM proxy. Validates the full intercept path that real Google API client libraries would take.

## Counts

| | unit | e2e | total |
|---|---|---|---|
| before | 150 | 45 | 195 |
| after  | **157** | **53** | **212** |

All 212 pass locally.

## Notes

- The branch was rebased onto current `main` (which now includes the e2e framework, MITM keep-alive fix, and gh/gws e2e suites). Force-pushed.
- The runtime fixture-injection endpoint (`POST /__fws/setup/search/fixture`) follows the same pattern as the existing `/__fws/setup/gmail/message` etc. — handy for tests but also for users who want to script search responses without editing seed data.
- Doesn't add a CLI subcommand (`fws setup search add-fixture`) since the existing `setup` command set is keyed off in-tree resources and there's no obvious "right" CLI shape yet. Easy followup if useful.

## Test plan
- [ ] CI `unit` job green (includes `test/search.test.ts`)
- [ ] CI `e2e` job green (includes `test/e2e/search.e2e.test.ts`)
- [ ] After merge, `gws/gh/curl` users can call `https://www.googleapis.com/customsearch/v1?q=...` through the proxy and get mock results

🤖 Generated with [Claude Code](https://claude.com/claude-code)
