### PR TITLE
Add Web Fetch fake service + flatten data-injection CLI (closes #1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,18 +57,7 @@ The server starts with sample seed data so you can try commands immediately.
 
 ## Usage
 
-### Proxy mode (one-shot)
-
-Starts a temporary server, runs gws, exits. No separate server needed.
-
-```bash
-fws gmail users messages list --params '{"userId":"me"}'
-fws gmail +triage
-fws calendar calendarList list
-fws drive about get --params '{"fields":"*"}'
-```
-
-### Server mode (persistent)
+### Start the server
 
 ```bash
 fws server start                  # Start in background
@@ -77,13 +66,40 @@ fws server stop                   # Stop
 fws server start --foreground     # Run in foreground (for debugging)
 ```
 
-### Setup (add data to running server)
+After starting, configure your shell so `gws`, `gh`, `curl`, etc. route
+through the mock:
 
 ```bash
-fws setup gmail add-message --from alice@corp.com --subject "Meeting" --body "See you at 3pm"
-fws setup calendar add-event --summary "Team sync" --start 2026-04-08T15:00:00 --duration 1h
-fws setup drive add-file --name "report.pdf" --mimeType application/pdf
+eval $(fws server env)
 ```
+
+Then run the CLI tools normally:
+
+```bash
+gws gmail users messages list --params '{"userId":"me"}'
+gws gmail +triage
+gh issue list
+curl https://example.com/        # mocked via Web Fetch (see below)
+```
+
+### Inject data into a running server
+
+Each service is its own top-level command. The action is `add` for all
+services that just take new entries.
+
+```bash
+fws gmail    add --from alice@corp.com --subject "Meeting" --body "See you at 3pm"
+fws calendar add --summary "Team sync" --start 2026-04-08T15:00:00 --duration 1h
+fws drive    add --name "report.pdf" --mimeType application/pdf
+fws search   add --keywords python,py --results '[{"title":"Python","link":"https://python.org/","displayLink":"python.org","snippet":"..."}]'
+fws fetch    add --url https://api.example.com/v1/echo --status 200 --body '{"hello":"world"}' --header 'content-type: application/json'
+```
+
+`fws fetch add` is the entry point to **Web Fetch** — a generic mock for
+arbitrary HTTP/HTTPS URLs. Adding a fixture for a URL or host
+automatically makes that host eligible for proxy interception, so any
+client routed through `HTTPS_PROXY` will see the mock instead of hitting
+the real internet.
 
 ### Snapshots
 

--- a/bin/fws.ts
+++ b/bin/fws.ts
@@ -1,10 +1,10 @@
 #!/usr/bin/env tsx
 import { Command } from 'commander';
 import { createApp } from '../src/server/app.js';
-import { resetStore, loadStore, serializeStore, deserializeStore } from '../src/store/index.js';
+import { loadStore, deserializeStore } from '../src/store/index.js';
 import { generateConfigDir } from '../src/config/rewrite-cache.js';
 import { generateCACert, startMitmProxy } from '../src/proxy/mitm.js';
-import { spawn, execFile } from 'node:child_process';
+import { spawn } from 'node:child_process';
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import os from 'node:os';
@@ -288,91 +288,175 @@ snapshotCmd
     console.log(`Snapshot deleted: ${name}`);
   });
 
-// === Setup commands ===
-const setupCmd = program.command('setup');
-const setupGmail = setupCmd.command('gmail');
+// === Service data-injection commands ===
+//
+// Each command is a thin wrapper around the corresponding /__fws/setup/...
+// HTTP endpoint on a running daemon. Naming convention is `fws <service>
+// <action>`, flat at the top level — no `setup` namespace, since the
+// service name is already the namespace.
 
-setupGmail
-  .command('add-message')
-  .description('Add a message to the mailbox')
-  .requiredOption('--from <email>', 'From address')
-  .option('--to <email>', 'To address')
-  .option('--subject <text>', 'Subject line')
-  .option('--body <text>', 'Message body')
-  .option('--labels <list>', 'Comma-separated label IDs', 'INBOX,UNREAD')
-  .option('-p, --port <port>', 'Server port', String(DEFAULT_PORT))
-  .action(async (opts) => {
-    const port = parseInt(opts.port);
-    const res = await fetch(`http://localhost:${port}/__fws/setup/gmail/message`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        from: opts.from,
-        to: opts.to,
-        subject: opts.subject,
-        body: opts.body,
-        labels: opts.labels.split(','),
-      }),
-    });
-    const data = await res.json();
-    console.log(`Message added: ${data.id}`);
+async function postSetup(port: number, urlPath: string, body: object): Promise<any> {
+  const res = await fetch(`http://localhost:${port}${urlPath}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
   });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`POST ${urlPath} failed: ${res.status} ${text}`);
+  }
+  return res.json();
+}
 
-const setupCalendar = setupCmd.command('calendar');
-
-setupCalendar
-  .command('add-event')
-  .description('Add an event to a calendar')
-  .requiredOption('--summary <text>', 'Event title')
-  .requiredOption('--start <datetime>', 'Start time (ISO 8601)')
-  .option('--duration <dur>', 'Duration (e.g. 30m, 1h, 2h)', '1h')
-  .option('--calendar <id>', 'Calendar ID', 'primary')
-  .option('--location <text>', 'Location')
-  .option('--attendees <list>', 'Comma-separated attendee emails')
-  .option('-p, --port <port>', 'Server port', String(DEFAULT_PORT))
-  .action(async (opts) => {
-    const port = parseInt(opts.port);
-    const res = await fetch(`http://localhost:${port}/__fws/setup/calendar/event`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        summary: opts.summary,
-        start: opts.start,
-        duration: opts.duration,
-        calendar: opts.calendar === 'primary' ? undefined : opts.calendar,
-        location: opts.location,
-        attendees: opts.attendees?.split(','),
+// fws gmail add
+program
+  .command('gmail')
+  .description("Inject data into the running daemon's gmail mailbox")
+  .addCommand(
+    new Command('add')
+      .description('Add a message to the mailbox')
+      .requiredOption('--from <email>', 'From address')
+      .option('--to <email>', 'To address')
+      .option('--subject <text>', 'Subject line')
+      .option('--body <text>', 'Message body')
+      .option('--labels <list>', 'Comma-separated label IDs', 'INBOX,UNREAD')
+      .option('-p, --port <port>', 'Server port', String(DEFAULT_PORT))
+      .action(async (opts) => {
+        const port = parseInt(opts.port);
+        const data = await postSetup(port, '/__fws/setup/gmail/message', {
+          from: opts.from,
+          to: opts.to,
+          subject: opts.subject,
+          body: opts.body,
+          labels: opts.labels.split(','),
+        });
+        console.log(`Message added: ${data.id}`);
       }),
-    });
-    const data = await res.json();
-    console.log(`Event added: ${data.id}`);
-  });
+  );
 
-const setupDrive = setupCmd.command('drive');
-
-setupDrive
-  .command('add-file')
-  .description('Add a file to Drive')
-  .requiredOption('--name <text>', 'File name')
-  .option('--mimeType <type>', 'MIME type', 'application/octet-stream')
-  .option('--parent <id>', 'Parent folder ID', 'root')
-  .option('--size <bytes>', 'File size in bytes')
-  .option('-p, --port <port>', 'Server port', String(DEFAULT_PORT))
-  .action(async (opts) => {
-    const port = parseInt(opts.port);
-    const res = await fetch(`http://localhost:${port}/__fws/setup/drive/file`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        name: opts.name,
-        mimeType: opts.mimeType,
-        parent: opts.parent,
-        size: opts.size ? parseInt(opts.size) : undefined,
+// fws calendar add
+program
+  .command('calendar')
+  .description("Inject data into the running daemon's calendar")
+  .addCommand(
+    new Command('add')
+      .description('Add an event to a calendar')
+      .requiredOption('--summary <text>', 'Event title')
+      .requiredOption('--start <datetime>', 'Start time (ISO 8601)')
+      .option('--duration <dur>', 'Duration (e.g. 30m, 1h, 2h)', '1h')
+      .option('--calendar <id>', 'Calendar ID', 'primary')
+      .option('--location <text>', 'Location')
+      .option('--attendees <list>', 'Comma-separated attendee emails')
+      .option('-p, --port <port>', 'Server port', String(DEFAULT_PORT))
+      .action(async (opts) => {
+        const port = parseInt(opts.port);
+        const data = await postSetup(port, '/__fws/setup/calendar/event', {
+          summary: opts.summary,
+          start: opts.start,
+          duration: opts.duration,
+          calendar: opts.calendar === 'primary' ? undefined : opts.calendar,
+          location: opts.location,
+          attendees: opts.attendees?.split(','),
+        });
+        console.log(`Event added: ${data.id}`);
       }),
-    });
-    const data = await res.json();
-    console.log(`File added: ${data.id}`);
-  });
+  );
+
+// fws drive add
+program
+  .command('drive')
+  .description("Inject data into the running daemon's drive")
+  .addCommand(
+    new Command('add')
+      .description('Add a file to Drive')
+      .requiredOption('--name <text>', 'File name')
+      .option('--mimeType <type>', 'MIME type', 'application/octet-stream')
+      .option('--parent <id>', 'Parent folder ID', 'root')
+      .option('--size <bytes>', 'File size in bytes')
+      .option('-p, --port <port>', 'Server port', String(DEFAULT_PORT))
+      .action(async (opts) => {
+        const port = parseInt(opts.port);
+        const data = await postSetup(port, '/__fws/setup/drive/file', {
+          name: opts.name,
+          mimeType: opts.mimeType,
+          parent: opts.parent,
+          size: opts.size ? parseInt(opts.size) : undefined,
+        });
+        console.log(`File added: ${data.id}`);
+      }),
+  );
+
+// fws search add
+program
+  .command('search')
+  .description("Inject Custom Search fixtures")
+  .addCommand(
+    new Command('add')
+      .description('Add a Custom Search fixture (keywords → results)')
+      .requiredOption('--keywords <list>', 'Comma-separated keywords (case-insensitive substring match)')
+      .requiredOption('--results <json>', 'JSON array of {title,link,displayLink,snippet}')
+      .option('-p, --port <port>', 'Server port', String(DEFAULT_PORT))
+      .action(async (opts) => {
+        const port = parseInt(opts.port);
+        let results: unknown;
+        try {
+          results = JSON.parse(opts.results);
+        } catch (e) {
+          console.error(`--results is not valid JSON: ${(e as Error).message}`);
+          process.exit(1);
+        }
+        await postSetup(port, '/__fws/setup/search/fixture', {
+          keywords: opts.keywords.split(','),
+          results,
+        });
+        console.log('Search fixture added');
+      }),
+  );
+
+// fws fetch add
+program
+  .command('fetch')
+  .description('Inject Web Fetch fixtures (mock arbitrary HTTP/HTTPS URLs)')
+  .addCommand(
+    new Command('add')
+      .description('Add a Web Fetch fixture. Specify either --url (exact match) or --host (any path on this host).')
+      .option('--url <url>', 'Exact URL to mock (https://example.com/foo)')
+      .option('--host <host>', 'Hostname to mock (example.com — matches any path)')
+      .option('--method <verb>', 'HTTP method to filter on (omit for any)')
+      .option('--status <code>', 'Response status code', '200')
+      .option('--body <text>', 'Response body (string)', '')
+      .option('--header <kv...>', 'Response header in "Name: Value" form (repeatable)')
+      .option('-p, --port <port>', 'Server port', String(DEFAULT_PORT))
+      .action(async (opts) => {
+        if (!opts.url && !opts.host) {
+          console.error('one of --url or --host is required');
+          process.exit(1);
+        }
+        const headers: Record<string, string> = {};
+        if (Array.isArray(opts.header)) {
+          for (const h of opts.header) {
+            const idx = (h as string).indexOf(':');
+            if (idx <= 0) {
+              console.error(`bad --header value (expected "Name: Value"): ${h}`);
+              process.exit(1);
+            }
+            headers[(h as string).slice(0, idx).trim()] = (h as string).slice(idx + 1).trim();
+          }
+        }
+        const port = parseInt(opts.port);
+        await postSetup(port, '/__fws/setup/fetch/fixture', {
+          url: opts.url,
+          host: opts.host,
+          method: opts.method,
+          response: {
+            status: parseInt(opts.status),
+            headers: Object.keys(headers).length > 0 ? headers : undefined,
+            body: opts.body,
+          },
+        });
+        console.log('Fetch fixture added');
+      }),
+  );
 
 // === Reset command ===
 program
@@ -398,53 +482,15 @@ program
     }
   });
 
-// === Proxy mode (default): start server, run gws, exit ===
-// If first arg is not a known subcommand, treat as gws proxy
-const SUBCOMMANDS = ['server', 'snapshot', 'setup', 'reset', 'help', '--help', '-h', '--version', '-V'];
+// The implicit "proxy mode" (any unknown first-arg → spawn temporary
+// daemon and forward to gws) used to live here. It was removed because
+// the flat top-level commands (`fws gmail add`, `fws calendar add`, ...)
+// conflict with the gws command names it would forward (`fws gmail
+// users messages list`). The replacement is the explicit two-step:
+//
+//   fws server start
+//   eval $(fws server env)
+//   gws gmail users messages list
+//   fws server stop
 
-async function runProxy(args: string[]): Promise<void> {
-  const port = DEFAULT_PORT;
-  const proxyPort = DEFAULT_PROXY_PORT;
-
-  // Start server in-process
-  const configDir = await fs.mkdtemp(path.join(os.tmpdir(), 'fws-proxy-'));
-  await generateConfigDir(port, configDir);
-
-  // Generate CA and start MITM proxy
-  const dataDir = await fs.mkdtemp(path.join(os.tmpdir(), 'fws-proxy-data-'));
-  const { caPath } = await generateCACert(dataDir);
-  const proxyServer = startMitmProxy(port, proxyPort);
-
-  const app = createApp();
-  const server: Server = await new Promise((resolve) => {
-    const s = app.listen(port, () => resolve(s));
-  });
-
-  const gwsPath = process.env.GWS_PATH || 'gws';
-  const env = {
-    ...process.env,
-    GOOGLE_WORKSPACE_CLI_CONFIG_DIR: configDir,
-    GOOGLE_WORKSPACE_CLI_TOKEN: 'fake',
-    HTTPS_PROXY: `http://localhost:${proxyPort}`,
-    SSL_CERT_FILE: caPath,
-  };
-
-  const child = spawn(gwsPath, args, { env, stdio: 'inherit' });
-
-  child.on('close', async (code) => {
-    server.close();
-    proxyServer.close();
-    await fs.rm(configDir, { recursive: true, force: true });
-    await fs.rm(dataDir, { recursive: true, force: true });
-    process.exit(code ?? 0);
-  });
-}
-
-// Main entry
-const firstArg = process.argv[2];
-if (firstArg && !SUBCOMMANDS.includes(firstArg)) {
-  // Proxy mode
-  runProxy(process.argv.slice(2));
-} else {
-  program.parse();
-}
+program.parse();

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -28,13 +28,29 @@ Stop the running server.
 
 Show whether the server is running and on which port.
 
+### `fws server env`
+
+Print the env-var exports a child process needs to talk to the running daemon
+(GOOGLE_WORKSPACE_CLI_CONFIG_DIR, HTTPS_PROXY, SSL_CERT_FILE, GH_TOKEN, etc.).
+Use with `eval`:
+
+```bash
+fws server start
+eval $(fws server env)
+gws gmail users messages list --params '{"userId":"me"}'
+gh issue list
+fws server stop
+```
+
 ---
 
-## Setup
+## Service data injection
 
-Convenience commands to seed data into a running server. The server must be running first (`fws server start`).
+Each service that supports runtime data injection has a top-level command.
+Common pattern: `fws <service> add ...`. The server must be running first
+(`fws server start`).
 
-### `fws setup gmail add-message`
+### `fws gmail add`
 
 Add an email message to the mailbox.
 
@@ -48,35 +64,14 @@ Add an email message to the mailbox.
 | `-p, --port <port>` | no | Server port | `4100` |
 
 ```bash
-fws setup gmail add-message --from alice@company.com --subject "Meeting" --body "See you at 3pm"
-fws setup gmail add-message --from bot@ci.com --subject "Build failed" --labels INBOX,UNREAD,IMPORTANT
-fws setup gmail add-message --from me@example.com --to bob@example.com --subject "Reply" --labels SENT
+fws gmail add --from alice@company.com --subject "Meeting" --body "See you at 3pm"
+fws gmail add --from bot@ci.com --subject "Build failed" --labels INBOX,UNREAD,IMPORTANT
+fws gmail add --from me@example.com --to bob@example.com --subject "Reply" --labels SENT
 ```
-
-**HTTP API equivalent:**
-
-```bash
-curl -X POST http://localhost:4100/__fws/setup/gmail/message \
-  -H 'Content-Type: application/json' \
-  -d '{"from":"alice@company.com","subject":"Meeting","body":"See you at 3pm","labels":["INBOX","UNREAD"]}'
-```
-
-Request body fields:
-
-| Field | Type | Description |
-|-------|------|-------------|
-| `from` | string | Sender address |
-| `to` | string | Recipient address |
-| `subject` | string | Subject line |
-| `body` | string | Message body |
-| `labels` | string[] | Label IDs |
-| `date` | string | ISO 8601 date (defaults to now) |
-
-Response: `{ "id": "...", "threadId": "..." }`
 
 ---
 
-### `fws setup calendar add-event`
+### `fws calendar add`
 
 Add a calendar event.
 
@@ -93,36 +88,14 @@ Add a calendar event.
 End time is computed automatically from `start + duration`.
 
 ```bash
-fws setup calendar add-event --summary "Standup" --start 2026-04-08T09:00:00
-fws setup calendar add-event --summary "Lunch" --start 2026-04-08T12:00:00 --duration 1h --location "Cafeteria"
-fws setup calendar add-event --summary "Review" --start 2026-04-08T14:00:00 --duration 30m --attendees alice@co.com,bob@co.com
+fws calendar add --summary "Standup" --start 2026-04-08T09:00:00
+fws calendar add --summary "Lunch" --start 2026-04-08T12:00:00 --duration 1h --location "Cafeteria"
+fws calendar add --summary "Review" --start 2026-04-08T14:00:00 --duration 30m --attendees alice@co.com,bob@co.com
 ```
-
-**HTTP API equivalent:**
-
-```bash
-curl -X POST http://localhost:4100/__fws/setup/calendar/event \
-  -H 'Content-Type: application/json' \
-  -d '{"summary":"Standup","start":"2026-04-08T09:00:00Z","duration":"30m"}'
-```
-
-Request body fields:
-
-| Field | Type | Description |
-|-------|------|-------------|
-| `summary` | string | Event title |
-| `start` | string | ISO 8601 start time |
-| `duration` | string | Duration (`30m`, `1h`, `2h`, `1d`) — default `1h` |
-| `description` | string | Event description |
-| `location` | string | Location |
-| `calendar` | string | Calendar ID (omit for primary) |
-| `attendees` | string[] | Attendee email addresses |
-
-Response: `{ "id": "...", "calendarId": "..." }`
 
 ---
 
-### `fws setup drive add-file`
+### `fws drive add`
 
 Add a file (metadata only) to Drive.
 
@@ -135,30 +108,72 @@ Add a file (metadata only) to Drive.
 | `-p, --port <port>` | no | Server port | `4100` |
 
 ```bash
-fws setup drive add-file --name "report.pdf" --mimeType application/pdf
-fws setup drive add-file --name "Project Docs" --mimeType application/vnd.google-apps.folder
-fws setup drive add-file --name "notes.txt" --mimeType text/plain --parent folder001 --size 1024
+fws drive add --name "report.pdf" --mimeType application/pdf
+fws drive add --name "Project Docs" --mimeType application/vnd.google-apps.folder
+fws drive add --name "notes.txt" --mimeType text/plain --parent folder001 --size 1024
 ```
 
-**HTTP API equivalent:**
+---
+
+### `fws search add`
+
+Add a Custom Search fixture (keywords → results). Used by the Search fake
+service that mocks the Google Custom Search JSON API at `/customsearch/v1`.
+
+| Flag | Required | Description |
+|------|----------|-------------|
+| `--keywords <list>` | **yes** | Comma-separated keywords (case-insensitive substring match against query) |
+| `--results <json>` | **yes** | JSON array of `{title, link, displayLink, snippet}` |
+| `-p, --port <port>` | no | Server port (default `4100`) |
 
 ```bash
-curl -X POST http://localhost:4100/__fws/setup/drive/file \
-  -H 'Content-Type: application/json' \
-  -d '{"name":"report.pdf","mimeType":"application/pdf"}'
+fws search add \
+  --keywords python,py \
+  --results '[{"title":"Python","link":"https://python.org/","displayLink":"python.org","snippet":"The Python language."}]'
 ```
 
-Request body fields:
+---
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `name` | string | File name |
-| `mimeType` | string | MIME type |
-| `parent` | string | Parent folder ID |
-| `size` | number | File size in bytes |
-| `description` | string | File description |
+### `fws fetch add`
 
-Response: `{ "id": "..." }`
+Add a Web Fetch fixture — a mock for arbitrary HTTP/HTTPS URLs accessed
+through the MITM proxy. Adding a fixture for a URL or host automatically
+makes that host eligible for proxy interception, so any client routed
+through `HTTPS_PROXY` will get the mock back instead of hitting the real
+internet.
+
+| Flag | Required | Description | Default |
+|------|----------|-------------|---------|
+| `--url <url>` | one of url/host | Exact URL to mock (`https://example.com/foo`) | — |
+| `--host <host>` | one of url/host | Hostname to mock (matches any path) | — |
+| `--method <verb>` | no | HTTP method to filter on (omit for any) | — |
+| `--status <code>` | no | Response status code | `200` |
+| `--body <text>` | no | Response body | empty |
+| `--header <kv...>` | no | Response header in `Name: Value` form (repeatable) | — |
+| `-p, --port <port>` | no | Server port | `4100` |
+
+```bash
+# Exact URL match
+fws fetch add \
+  --url https://api.example.com/v1/echo \
+  --status 200 \
+  --body '{"hello":"world"}' \
+  --header 'content-type: application/json'
+
+# Host-only match (any path on this host)
+fws fetch add \
+  --host blog.example.com \
+  --status 200 \
+  --body '<h1>Mocked blog</h1>' \
+  --header 'content-type: text/html'
+
+# Method-filtered fixture
+fws fetch add \
+  --url https://api.example.com/v1/submit \
+  --method POST \
+  --status 201 \
+  --body '{"created":true}'
+```
 
 ---
 
@@ -166,7 +181,8 @@ Response: `{ "id": "..." }`
 
 All data is in-memory. Snapshots save/restore the full server state to disk.
 
-Stored in `~/.local/share/fws/snapshots/<name>/store.json` (override with `FWS_DATA_DIR`).
+Stored in `~/.local/share/fws/snapshots/<name>/store.json` (override with
+`FWS_DATA_DIR`).
 
 ### `fws snapshot save <name>`
 
@@ -195,17 +211,3 @@ Reset server to default seed data.
 ### `fws reset --snapshot <name>`
 
 Reset server to a specific snapshot.
-
----
-
-## Proxy mode
-
-Any command that doesn't match a built-in subcommand is forwarded to `gws` through a temporary mock server.
-
-```bash
-fws gmail users messages list --params '{"userId":"me"}'
-fws drive files list
-fws calendar events list --params '{"calendarId":"primary"}'
-```
-
-This starts a server, runs the gws command, and exits. No `fws server start` needed.

--- a/src/proxy/mitm.ts
+++ b/src/proxy/mitm.ts
@@ -4,6 +4,7 @@ import http from 'node:http';
 import crypto from 'node:crypto';
 import fs from 'node:fs/promises';
 import path from 'node:path';
+import { hasFixtureForHost } from '../server/routes/fetch.js';
 
 const INTERCEPTED_HOSTS = [
   // Google Workspace
@@ -141,18 +142,42 @@ async function getHostCert(hostname: string): Promise<CertPair> {
   return pair;
 }
 
+function isAllowlistedHost(hostname: string): boolean {
+  return INTERCEPTED_HOSTS.some(h => hostname === h || hostname.endsWith('.' + h));
+}
+
+/**
+ * Decide whether to intercept a host instead of passing it through to the
+ * real internet. Two reasons to intercept:
+ *  1. The host is in the built-in service allowlist (gmail.googleapis.com,
+ *     api.github.com, ...).
+ *  2. There is at least one Web Fetch fixture covering this host. Adding a
+ *     fixture for `https://example.com/foo` automatically makes example.com
+ *     eligible for interception, so users don't have to flip a global flag.
+ *
+ * The Web Fetch store is read on each CONNECT, so adding a fixture at
+ * runtime takes effect for new connections immediately.
+ */
+function shouldInterceptHost(hostname: string): boolean {
+  if (isAllowlistedHost(hostname)) return true;
+  return hasFixtureForHost(hostname);
+}
+
 export function startMitmProxy(mockPort: number, proxyPort: number): http.Server {
-  const proxy = http.createServer((_req, res) => {
-    res.writeHead(405);
-    res.end('MITM proxy only supports CONNECT');
+  // Plain HTTP requests (when the client uses HTTP_PROXY for an http:// URL)
+  // arrive here as ordinary requests with an absolute URL in the request line.
+  // Forward them to the mock server with X-Fws-Original-Host so the catch-all
+  // route can route them, OR pass them through to the real internet when the
+  // host is not intercepted.
+  const proxy = http.createServer((req, res) => {
+    handlePlainHttp(req, res, mockPort);
   });
 
   proxy.on('connect', async (req, clientSocket, head) => {
     const [hostname, portStr] = (req.url || '').split(':');
     const port = parseInt(portStr) || 443;
 
-    // Only intercept googleapis.com hosts
-    if (!INTERCEPTED_HOSTS.some(h => hostname === h || hostname.endsWith('.' + h))) {
+    if (!shouldInterceptHost(hostname)) {
       // Pass through to real server
       const serverSocket = net.connect(port, hostname, () => {
         clientSocket.write('HTTP/1.1 200 Connection Established\r\n\r\n');
@@ -191,6 +216,85 @@ export function startMitmProxy(mockPort: number, proxyPort: number): http.Server
 
   proxy.listen(proxyPort);
   return proxy;
+}
+
+/**
+ * Handle a plain (non-CONNECT) HTTP request received by the proxy. This is
+ * the path curl/wget take when given `HTTP_PROXY` for an `http://` URL: the
+ * client sends `GET http://example.com/foo HTTP/1.1` directly to the proxy
+ * (note: absolute URL in request line, per HTTP/1.1 §5.3.2).
+ *
+ * If the host is in the intercept set, forward to the mock server with
+ * `X-Fws-Original-Host` so the catch-all route can find a fixture. Otherwise
+ * pass the request through to the real internet (mirrors the CONNECT
+ * passthrough for HTTPS).
+ */
+function handlePlainHttp(
+  req: http.IncomingMessage,
+  res: http.ServerResponse,
+  mockPort: number,
+): void {
+  const reqUrl = req.url || '';
+  let parsed: URL;
+  try {
+    parsed = new URL(reqUrl);
+  } catch {
+    res.writeHead(400);
+    res.end('Bad Request: expected absolute URL in request line');
+    return;
+  }
+
+  const hostname = parsed.hostname;
+
+  if (!shouldInterceptHost(hostname)) {
+    // Passthrough: open a TCP connection and forward the request unchanged.
+    const upstream = http.request(
+      {
+        hostname,
+        port: parsed.port ? parseInt(parsed.port) : 80,
+        method: req.method,
+        path: parsed.pathname + parsed.search,
+        headers: req.headers,
+      },
+      (upRes) => {
+        res.writeHead(upRes.statusCode ?? 502, upRes.headers);
+        upRes.pipe(res);
+      },
+    );
+    upstream.on('error', () => {
+      res.writeHead(502);
+      res.end('Bad Gateway');
+    });
+    req.pipe(upstream);
+    return;
+  }
+
+  // Intercepted: forward to local mock server with markers identifying the
+  // original host and scheme so the Web Fetch catch-all can build the
+  // canonical URL for fixture lookup.
+  const mockReq = http.request(
+    {
+      hostname: 'localhost',
+      port: mockPort,
+      method: req.method,
+      path: parsed.pathname + parsed.search,
+      headers: {
+        ...req.headers,
+        host: `localhost:${mockPort}`,
+        'x-fws-original-host': hostname,
+        'x-fws-original-scheme': 'http',
+      },
+    },
+    (mockRes) => {
+      res.writeHead(mockRes.statusCode ?? 502, mockRes.headers);
+      mockRes.pipe(res);
+    },
+  );
+  mockReq.on('error', () => {
+    res.writeHead(502);
+    res.end('Bad Gateway');
+  });
+  req.pipe(mockReq);
 }
 
 function handleInterceptedRequest(tlsSocket: tls.TLSSocket, hostname: string, mockPort: number): void {
@@ -275,7 +379,14 @@ function handleInterceptedRequest(tlsSocket: tls.TLSSocket, hostname: string, mo
         port: mockPort,
         path: urlPath,
         method,
-        headers: { ...headers, host: `localhost:${mockPort}` },
+        headers: {
+          ...headers,
+          host: `localhost:${mockPort}`,
+          // Markers for the Web Fetch catch-all so it can build the
+          // canonical URL for fixture lookup.
+          'x-fws-original-host': hostname,
+          'x-fws-original-scheme': 'https',
+        },
       },
       (mockRes) => {
         // Buffer the upstream response so we can write it as a single

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -7,6 +7,7 @@ import { sheetsRoutes } from './routes/sheets.js';
 import { peopleRoutes } from './routes/people.js';
 import { githubRoutes } from './routes/github.js';
 import { searchRoutes } from './routes/search.js';
+import { webFetchRoutes, webFetchCatchAll } from './routes/fetch.js';
 import { controlRoutes } from './routes/control.js';
 import { errorHandler } from './middleware.js';
 
@@ -23,6 +24,12 @@ export function createApp(): express.Express {
   app.use(peopleRoutes());
   app.use(githubRoutes());
   app.use(searchRoutes());
+  app.use(webFetchRoutes());
+
+  // Web Fetch catch-all must be last (before errorHandler) so it only
+  // intercepts requests that no real route handled. Limited to requests
+  // that arrived via the MITM proxy by checking X-Fws-Original-Host.
+  app.use(webFetchCatchAll());
 
   app.use(errorHandler);
 

--- a/src/server/routes/fetch.ts
+++ b/src/server/routes/fetch.ts
@@ -1,0 +1,178 @@
+import { Router, type RequestHandler } from 'express';
+import { getStore } from '../../store/index.js';
+import type { WebFetchFixture, WebFetchResponse } from '../../store/types.js';
+
+/**
+ * Web Fetch — generic HTTP/HTTPS mocking for arbitrary URLs.
+ *
+ * Two integration paths:
+ *
+ *   1. Direct API: `GET /__fws/fetch?url=...&method=GET` returns the matched
+ *      fixture as JSON metadata. Useful for programmatic checks and tests
+ *      that don't want to spin up the proxy.
+ *
+ *   2. MITM proxy catch-all: when the MITM proxy intercepts a host (either
+ *      because it's in the built-in allowlist OR because the host has at
+ *      least one Web Fetch fixture) and forwards the request here, the
+ *      proxy adds an `X-Fws-Original-Host` header. After all the explicit
+ *      service routes (gmail, github, etc.) have had a chance to match,
+ *      `webFetchCatchAll` serves a fixture (or the hardcoded default).
+ *
+ * Setup endpoint (called by `fws fetch add`, not user-facing as curl):
+ *
+ *   POST /__fws/setup/fetch/fixture — add a fixture
+ */
+
+/**
+ * Hardcoded default response for the case where a host got intercepted
+ * (because some other path on it has a fixture) but the specific request
+ * URL has no matching fixture. Just gives the client *something* back so
+ * the failure mode is "got a generic mock body" rather than "request hung".
+ * This is intentionally not user-configurable — see the design discussion
+ * around the simplification of Web Fetch.
+ */
+const HARDCODED_DEFAULT: WebFetchResponse = {
+  status: 200,
+  headers: { 'content-type': 'application/json' },
+  body: JSON.stringify({ mock: true, source: 'fws-web-fetch-default' }),
+};
+
+export function webFetchRoutes(): Router {
+  const r = Router();
+
+  // Direct API: look up a URL without going through the proxy.
+  r.get('/__fws/fetch', (req, res) => {
+    const url = String(req.query.url ?? '');
+    const method = String(req.query.method ?? 'GET').toUpperCase();
+    if (!url) {
+      return res.status(400).json({ error: 'url query parameter is required' });
+    }
+    const lookup = lookupFixture(url, method);
+    res.json({
+      url,
+      method,
+      matched: lookup.matched,
+      fixture: lookup.fixture ?? null,
+      response: lookup.response,
+    });
+  });
+
+  // Setup: add a fixture at runtime. Called by `fws fetch add`.
+  r.post('/__fws/setup/fetch/fixture', (req, res) => {
+    const store = getStore();
+    const body = req.body || {};
+    if (!body.url && !body.host) {
+      return res.status(400).json({ error: 'fixture must specify url or host' });
+    }
+    if (!body.response || typeof body.response.status !== 'number' || typeof body.response.body !== 'string') {
+      return res.status(400).json({ error: 'fixture.response must include status (number) and body (string)' });
+    }
+    const fixture: WebFetchFixture = {
+      url: body.url,
+      host: body.host,
+      method: body.method ? String(body.method).toUpperCase() : undefined,
+      response: {
+        status: body.response.status,
+        headers: body.response.headers,
+        body: body.response.body,
+      },
+    };
+    store.webFetch.fixtures.push(fixture);
+    res.json({ status: 'added', count: store.webFetch.fixtures.length });
+  });
+
+  return r;
+}
+
+/**
+ * Catch-all middleware. Registered AFTER all the explicit service routes.
+ * When the MITM proxy intercepts a host and forwards it here with
+ * `X-Fws-Original-Host`, this responds with a fixture (or the hardcoded
+ * default). Requests without that header are direct test fetches and
+ * fall through to Express's default 404.
+ */
+export function webFetchCatchAll(): RequestHandler {
+  return (req, res, next) => {
+    const originalHost = req.header('x-fws-original-host');
+    if (!originalHost) {
+      return next();
+    }
+
+    const scheme = req.header('x-fws-original-scheme') || 'https';
+    const url = `${scheme}://${originalHost}${req.originalUrl}`;
+    const method = req.method.toUpperCase();
+
+    const { response } = lookupFixture(url, method);
+
+    if (response.headers) {
+      for (const [k, v] of Object.entries(response.headers)) {
+        res.setHeader(k, v);
+      }
+    }
+    res.status(response.status).send(response.body);
+  };
+}
+
+/**
+ * Used by the MITM proxy to decide whether to intercept a host: if any
+ * fixture in the store covers this host (either via host= or via the host
+ * portion of url=), the proxy intercepts that host alongside the built-in
+ * service allowlist.
+ */
+export function hasFixtureForHost(hostname: string): boolean {
+  try {
+    const store = getStore();
+    return store.webFetch.fixtures.some(fix => {
+      if (fix.host === hostname) return true;
+      if (fix.url) {
+        try {
+          return new URL(fix.url).host === hostname;
+        } catch {
+          return false;
+        }
+      }
+      return false;
+    });
+  } catch {
+    return false;
+  }
+}
+
+interface LookupResult {
+  matched: 'url' | 'host' | 'default';
+  fixture: WebFetchFixture | null;
+  response: WebFetchResponse;
+}
+
+function lookupFixture(url: string, method: string): LookupResult {
+  const store = getStore();
+  const upperMethod = method.toUpperCase();
+
+  let host: string | undefined;
+  try {
+    host = new URL(url).host;
+  } catch {
+    // not parseable — host-only matches won't fire
+  }
+
+  // 1. Exact URL match (with optional method filter)
+  for (const fix of store.webFetch.fixtures) {
+    if (!fix.url) continue;
+    if (fix.url !== url) continue;
+    if (fix.method && fix.method.toUpperCase() !== upperMethod) continue;
+    return { matched: 'url', fixture: fix, response: fix.response };
+  }
+
+  // 2. Host-only match
+  if (host) {
+    for (const fix of store.webFetch.fixtures) {
+      if (!fix.host) continue;
+      if (fix.host !== host) continue;
+      if (fix.method && fix.method.toUpperCase() !== upperMethod) continue;
+      return { matched: 'host', fixture: fix, response: fix.response };
+    }
+  }
+
+  // 3. Hardcoded default
+  return { matched: 'default', fixture: null, response: HARDCODED_DEFAULT };
+}

--- a/src/store/seed.ts
+++ b/src/store/seed.ts
@@ -1,4 +1,4 @@
-import type { FwsStore, GmailLabel, GmailMessage, CalendarEvent, DriveFile, TaskList, Task, Spreadsheet, Person, ContactGroup, GitHubStore, SearchStore } from './types.js';
+import type { FwsStore, GmailLabel, GmailMessage, CalendarEvent, DriveFile, TaskList, Task, Spreadsheet, Person, ContactGroup, GitHubStore, SearchStore, WebFetchStore } from './types.js';
 import { generateEtag } from '../util/id.js';
 
 const SYSTEM_LABELS: GmailLabel[] = [
@@ -410,6 +410,32 @@ export function createSeedStore(): FwsStore {
       },
     },
     search: createSearchSeed(),
+    webFetch: createWebFetchSeed(),
+  };
+}
+
+function createWebFetchSeed(): WebFetchStore {
+  return {
+    // Each fixture's host (or URL host) becomes eligible for proxy
+    // interception automatically — no global toggle.
+    fixtures: [
+      {
+        url: 'https://example.com/',
+        response: {
+          status: 200,
+          headers: { 'content-type': 'text/html; charset=utf-8' },
+          body: '<!doctype html><html><body><h1>Example Domain (mocked)</h1></body></html>',
+        },
+      },
+      {
+        host: 'httpbin.org',
+        response: {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ url: 'https://httpbin.org/', origin: '127.0.0.1', mock: true }),
+        },
+      },
+    ],
   };
 }
 

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -9,6 +9,7 @@ export interface FwsStore {
   people: PeopleStore;
   github: GitHubStore;
   search: SearchStore;
+  webFetch: WebFetchStore;
 }
 
 // === Gmail ===
@@ -328,4 +329,43 @@ export interface SearchResult {
   link: string;
   displayLink: string;
   snippet: string;
+}
+
+// === Web Fetch ===
+//
+// Generic mock layer for arbitrary HTTP/HTTPS URLs accessed via curl/wget
+// (or any HTTP client routed through the MITM proxy).
+//
+// Model is intentionally minimal: a fixture for a host (or specific URL)
+// makes that host eligible for proxy interception. Hosts without any
+// fixture are passed through to the real internet (in addition to the
+// built-in allowlist of known service hosts like gmail.googleapis.com).
+//
+// There is no global "intercept everything" flag and no user-configurable
+// default response — both turned out to be confusing knobs that the user
+// surface didn't actually need. If a host gets intercepted (because it
+// has a fixture for /v1) but a different path on the same host (/v2) is
+// requested with no matching fixture, the catch-all returns a hardcoded
+// default JSON body just so the client gets *something* back.
+
+export interface WebFetchStore {
+  /** Lookup order: exact URL first, then host-only. */
+  fixtures: WebFetchFixture[];
+}
+
+export interface WebFetchFixture {
+  /** Match the full URL exactly (including scheme, host, path, query). */
+  url?: string;
+  /** Match any path on this host (no scheme, just `example.com`). */
+  host?: string;
+  /** Match only this method (GET/POST/...). Omit to match any method. */
+  method?: string;
+  response: WebFetchResponse;
+}
+
+export interface WebFetchResponse {
+  status: number;
+  headers?: Record<string, string>;
+  /** Response body as a string. Use base64 + a Content-Encoding/Content-Type header for binary. */
+  body: string;
 }

--- a/test/e2e/fetch.e2e.test.ts
+++ b/test/e2e/fetch.e2e.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { startFwsDaemon, type CliHarness } from './helpers/cli-harness.js';
+
+/**
+ * E2E coverage for Web Fetch — real `curl` through the MITM proxy against
+ * the running daemon. Exercises the full pipeline:
+ *
+ *   curl → HTTP_PROXY/HTTPS_PROXY → mitm.ts → mock server → fetch.ts
+ *
+ * The seeded fixtures (example.com / httpbin.org) self-enable interception
+ * for those hosts — no global toggle needed.
+ */
+describe('e2e: Web Fetch through real proxy', () => {
+  let h: CliHarness;
+
+  beforeAll(async () => {
+    h = await startFwsDaemon();
+  });
+
+  afterAll(async () => {
+    await h.stop();
+  });
+
+  describe('HTTPS via CONNECT', () => {
+    it('serves the seeded example.com fixture to curl', async () => {
+      const { stdout, stderr, exitCode } = await h.run('curl', [
+        '-sf',
+        '--proxy', `http://localhost:${h.proxyPort}`,
+        '--cacert', h.caPath,
+        'https://example.com/',
+      ]);
+      expect(exitCode, `curl stderr: ${stderr}`).toBe(0);
+      expect(stdout).toContain('Example Domain (mocked)');
+    });
+
+    it('serves the seeded httpbin.org fixture (host-only match)', async () => {
+      const { stdout, stderr, exitCode } = await h.run('curl', [
+        '-sf',
+        '--proxy', `http://localhost:${h.proxyPort}`,
+        '--cacert', h.caPath,
+        'https://httpbin.org/anything/here?x=1',
+      ]);
+      expect(exitCode, `curl stderr: ${stderr}`).toBe(0);
+      const data = JSON.parse(stdout);
+      expect(data.mock).toBe(true);
+    });
+
+    it('runtime-injected fixture is reachable via curl', async () => {
+      // Add a fixture for a brand-new host. The host then becomes eligible
+      // for proxy interception automatically.
+      await h.fetch('/__fws/setup/fetch/fixture', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          url: 'https://api.injected.test/v1/echo',
+          response: {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+            body: JSON.stringify({ injected: 'yes', via: 'curl-e2e' }),
+          },
+        }),
+      });
+
+      const { stdout, stderr, exitCode } = await h.run('curl', [
+        '-sf',
+        '--proxy', `http://localhost:${h.proxyPort}`,
+        '--cacert', h.caPath,
+        'https://api.injected.test/v1/echo',
+      ]);
+      expect(exitCode, `curl stderr: ${stderr}`).toBe(0);
+      const data = JSON.parse(stdout);
+      expect(data.injected).toBe('yes');
+    });
+
+    it('passes through to the real internet for hosts with no fixture', async () => {
+      // Without a fixture, the proxy doesn't intercept random hosts.
+      // We can't easily test "real internet" in CI without flake, but we
+      // CAN verify that the proxy doesn't error out — it should attempt
+      // a TCP connection to a non-existent host, which fails cleanly.
+      const { exitCode } = await h.run('curl', [
+        '-s',
+        '-o', '/dev/null',
+        '-w', '%{http_code}',
+        '--max-time', '3',
+        '--proxy', `http://localhost:${h.proxyPort}`,
+        'https://nonexistent-host-fws-e2e.invalid/',
+      ]);
+      // curl exits non-zero (DNS failure / proxy 502) — that's the
+      // passthrough path failing as expected. The point is that we did
+      // NOT get a mocked response back.
+      expect(exitCode).not.toBe(0);
+    });
+  });
+
+  describe('Plain HTTP', () => {
+    it('curl http:// to host-only fixture matches regardless of scheme', async () => {
+      const { stdout, stderr, exitCode } = await h.run('curl', [
+        '-sf',
+        '--proxy', `http://localhost:${h.proxyPort}`,
+        'http://httpbin.org/anything',
+      ]);
+      expect(exitCode, `curl stderr: ${stderr}`).toBe(0);
+      const data = JSON.parse(stdout);
+      expect(data.mock).toBe(true);
+    });
+  });
+});

--- a/test/fetch.test.ts
+++ b/test/fetch.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { createTestHarness, type TestHarness } from './helpers/harness.js';
+
+describe('Web Fetch (generic HTTP/HTTPS mock)', () => {
+  let h: TestHarness;
+
+  beforeAll(async () => {
+    h = await createTestHarness();
+  });
+
+  afterAll(async () => {
+    await h.cleanup();
+  });
+
+  describe('GET /__fws/fetch direct API', () => {
+    it('returns 400 when url is missing', async () => {
+      const res = await h.fetch('/__fws/fetch');
+      expect(res.status).toBe(400);
+    });
+
+    it('returns the seeded example.com fixture as exact-url match', async () => {
+      const res = await h.fetch('/__fws/fetch?url=' + encodeURIComponent('https://example.com/'));
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.matched).toBe('url');
+      expect(data.response.status).toBe(200);
+      expect(data.response.body).toContain('Example Domain (mocked)');
+    });
+
+    it('returns the seeded httpbin.org fixture as host match', async () => {
+      const res = await h.fetch('/__fws/fetch?url=' + encodeURIComponent('https://httpbin.org/get'));
+      const data = await res.json();
+      expect(data.matched).toBe('host');
+      const body = JSON.parse(data.response.body);
+      expect(body.mock).toBe(true);
+    });
+
+    it('returns the hardcoded default for unmatched hosts', async () => {
+      const res = await h.fetch('/__fws/fetch?url=' + encodeURIComponent('https://random.example.test/foo'));
+      const data = await res.json();
+      expect(data.matched).toBe('default');
+      const body = JSON.parse(data.response.body);
+      expect(body.source).toBe('fws-web-fetch-default');
+    });
+  });
+
+  describe('runtime fixture injection', () => {
+    it('accepts a fixture via /__fws/setup/fetch/fixture', async () => {
+      const setup = await h.fetch('/__fws/setup/fetch/fixture', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          url: 'https://api.test.local/v1/foo',
+          response: {
+            status: 201,
+            headers: { 'content-type': 'application/json' },
+            body: JSON.stringify({ injected: true }),
+          },
+        }),
+      });
+      expect(setup.status).toBe(200);
+
+      const res = await h.fetch('/__fws/fetch?url=' + encodeURIComponent('https://api.test.local/v1/foo'));
+      const data = await res.json();
+      expect(data.matched).toBe('url');
+      expect(data.response.status).toBe(201);
+      expect(JSON.parse(data.response.body).injected).toBe(true);
+    });
+
+    it('rejects fixtures missing url and host', async () => {
+      const res = await h.fetch('/__fws/setup/fetch/fixture', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ response: { status: 200, body: 'x' } }),
+      });
+      expect(res.status).toBe(400);
+    });
+
+    it('rejects fixtures with malformed response', async () => {
+      const res = await h.fetch('/__fws/setup/fetch/fixture', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ url: 'https://x.test/', response: { body: 'no status' } }),
+      });
+      expect(res.status).toBe(400);
+    });
+
+    it('respects method filter on a fixture', async () => {
+      await h.fetch('/__fws/setup/fetch/fixture', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          url: 'https://method.test/',
+          method: 'POST',
+          response: { status: 200, body: 'post-only' },
+        }),
+      });
+
+      const get = await h.fetch('/__fws/fetch?url=' + encodeURIComponent('https://method.test/') + '&method=GET');
+      const getData = await get.json();
+      // GET doesn't match the POST-only fixture → falls through to default
+      expect(getData.matched).toBe('default');
+
+      const post = await h.fetch('/__fws/fetch?url=' + encodeURIComponent('https://method.test/') + '&method=POST');
+      const postData = await post.json();
+      expect(postData.matched).toBe('url');
+      expect(postData.response.body).toBe('post-only');
+    });
+  });
+
+  describe('catch-all middleware (simulated proxy headers)', () => {
+    beforeAll(async () => {
+      // Earlier tests injected fixtures; reset to seed so the catch-all
+      // assertions about default behavior are predictable.
+      await h.fetch('/__fws/reset', { method: 'POST' });
+    });
+
+    it('does NOT trigger without X-Fws-Original-Host', async () => {
+      const res = await h.fetch('/some/random/path/that/no/route/handles');
+      expect(res.status).toBe(404);
+    });
+
+    it('triggers with X-Fws-Original-Host and serves the matched fixture', async () => {
+      const res = await h.fetch('/', {
+        headers: {
+          'x-fws-original-host': 'example.com',
+          'x-fws-original-scheme': 'https',
+        },
+      });
+      expect(res.status).toBe(200);
+      const text = await res.text();
+      expect(text).toContain('Example Domain (mocked)');
+    });
+
+    it('returns the hardcoded default for an intercepted host without a matching fixture', async () => {
+      // example.com has a fixture for /, so the host gets intercepted, but
+      // a request for /some/other/path on the same host has no fixture →
+      // hardcoded default fires.
+      const res = await h.fetch('/some/other/path', {
+        headers: {
+          'x-fws-original-host': 'example.com',
+          'x-fws-original-scheme': 'https',
+        },
+      });
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.source).toBe('fws-web-fetch-default');
+    });
+
+    it('does NOT shadow real routes when intercepted host happens to match an existing path', async () => {
+      // Even with the original-host header set, if a real route matches
+      // the path, that route still wins (the catch-all only fires when no
+      // other route handled the request). This is the known path-collision
+      // limitation; documented separately.
+      const res = await h.fetch('/customsearch/v1?q=python&cx=abc', {
+        headers: { 'x-fws-original-host': 'www.googleapis.com' },
+      });
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.kind).toBe('customsearch#search');
+    });
+  });
+});


### PR DESCRIPTION
Closes juppytt/fws#1.

## Summary

Two things rolled into one PR because they're inseparable:

1. **Web Fetch** — a generic mock layer for arbitrary HTTP/HTTPS URLs accessed via `curl`/`wget` (or any HTTP client routed through the MITM proxy). Built for agent-isolation scenarios where the agent must not reach the real internet.

2. **CLI flattening** — `fws setup gmail add-message` → `fws gmail add`, plus new top-level commands for the previously curl-only services (search, fetch). The old `setup` namespace is gone.

## Web Fetch

### Model

Intentionally minimal:

```ts
WebFetchStore { fixtures: WebFetchFixture[] }

WebFetchFixture {
  url?: string         // exact URL match
  host?: string        // any path on this host
  method?: string      // omit for any method
  response: { status, headers?, body }
}
```

Adding a fixture for a host (or specific URL) makes that host eligible for proxy interception. There is **no global "intercept everything" toggle and no user-configurable default response** — earlier drafts had both, they were confusing knobs that the user surface didn't actually need.

When a host gets intercepted (because some other path on it has a fixture) but the specific URL has no matching fixture, the catch-all returns a hardcoded JSON default `{mock: true, source: "fws-web-fetch-default"}`. Users can't change this; if they need a custom response, they add a fixture.

### Proxy changes (`src/proxy/mitm.ts`)

- `shouldInterceptHost()` consults `hasFixtureForHost()` from the Web Fetch store in addition to the built-in service allowlist. Adding a fixture is the trigger; no separate flag.
- Forwarder adds `X-Fws-Original-Host` and `X-Fws-Original-Scheme` headers when forwarding intercepted requests to the mock.
- **Plain HTTP support**: the proxy used to return 405 for any non-CONNECT request. New `handlePlainHttp()` handles `GET http://example.com/foo HTTP/1.1` (the curl path for `HTTP_PROXY` on http:// URLs). Same intercept rule as CONNECT.

### Catch-all middleware (`src/server/routes/fetch.ts`)

Registered last in `app.ts`. Only fires when `X-Fws-Original-Host` is present, so it never shadows direct test 404s. Reconstructs the canonical URL from the proxy's headers + `req.originalUrl`, runs the fixture lookup, and writes the matched response.

## CLI flatten

### Old → new

```
fws setup gmail add-message --from ...    →  fws gmail    add --from ...
fws setup calendar add-event --summary ...  →  fws calendar add --summary ...
fws setup drive add-file --name ...         →  fws drive    add --name ...
                                              fws search   add --keywords ... --results ...   (NEW)
                                              fws fetch    add --url ... --status ... --body ... (NEW)
```

The `fws setup` namespace is gone. Each service is its own top-level command, with `add` as the universal verb. Search and Web Fetch get CLI commands for the first time — previously users had to `curl http://localhost:4100/__fws/setup/search/fixture` themselves, which was the inconsistency this PR fixes.

### Removed: implicit proxy mode

`bin/fws.ts` used to forward unrecognized first-args to `gws` (`fws gmail users messages list` → spawn temp daemon, run `gws gmail users messages list`, exit). This conflicts with the new `fws gmail add` command. Replacement is the explicit two-step:

```bash
fws server start
eval $(fws server env)
gws gmail users messages list
fws server stop
```

## Tests

| File | Tests |
|---|---|
| `test/fetch.test.ts` | **12 unit** — direct API, fixture inject, malformed body rejection, method filter, catch-all (positive / no-header fallthrough / default fallback / non-shadowing) |
| `test/e2e/fetch.e2e.test.ts` | **5 e2e** — real `curl` through the daemon proxy: HTTPS exact-URL, HTTPS host-only, HTTPS runtime-injected, HTTPS passthrough for unknown host, plain HTTP host-only |

229 tests pass locally (162 unit + 67 e2e).

## Known limitations / followups

- **Path collision**: a Web Fetch fixture whose URL path matches an existing service route's path (e.g., `https://my-api.test/gmail/v1/users/me/profile`) will be shadowed by the real gmail route. Needs a dispatcher middleware that checks `X-Fws-Original-Host` before routing. Left for a separate PR — orthogonal concern. Documented in the unit test `does NOT shadow real routes...`.
- Web Fetch body type is `string`, not `Buffer`. Binary content can be base64-encoded by the user with an appropriate `Content-Type`.
- Proxy still doesn't support `Transfer-Encoding: chunked` on request bodies. Same limitation as before; gh/gws/curl POSTs use `Content-Length`.

## Test plan

- [ ] PR `unit` job green
- [ ] PR `e2e` job green
- [ ] After merge: `fws fetch add --url ...` + `curl ...` flow works in the README

🤖 Generated with [Claude Code](https://claude.com/claude-code)
