### PR TITLE
Fix Web Fetch path collision (fixes #15) + docs/proxy.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,8 @@ Snapshots are stored in `~/.local/share/fws/snapshots/` (override with `FWS_DATA
 
 ## Documentation
 
-- [docs/cli-reference.md](docs/cli-reference.md) — CLI reference with all flags, HTTP API equivalents, and examples
+- [docs/cli-reference.md](docs/cli-reference.md) — CLI reference with all flags and examples
+- [docs/proxy.md](docs/proxy.md) — How fws routes outbound HTTP traffic (intercept rules, header conventions, path-collision handling)
 - [docs/gws-support.md](docs/gws-support.md) — Google Workspace endpoint support table
 - [docs/gh-support.md](docs/gh-support.md) — GitHub endpoint support table
 

--- a/docs/proxy.md
+++ b/docs/proxy.md
@@ -1,0 +1,297 @@
+# How fws routes outbound HTTP traffic
+
+This doc explains, end to end, what happens when an agent or CLI tool
+makes an HTTP/HTTPS request through `fws` — from the moment the request
+leaves `curl`/`gh`/`gws` to the moment a mock response comes back. Read
+this if you're confused about which mock served which request, or if
+you're adding a new fake service that needs to play nicely with the
+proxy.
+
+## The actors
+
+```
+┌──────────────┐    HTTPS_PROXY/    ┌────────────┐  forward  ┌─────────────┐
+│ curl / gh /  │ ───────HTTP_PROXY──▶│ MITM proxy │──────────▶│ Mock server │
+│ gws / your   │                     │  (mitm.ts) │           │  (Express)  │
+│ agent        │ ◀────response───────│            │◀──────────│             │
+└──────────────┘                     └────────────┘           └─────────────┘
+```
+
+- **`fws server start`** spawns one daemon process containing both
+  the **MITM proxy** and the **mock server**.
+- The **mock server** is an Express app with one router per fake
+  service (`gmail`, `calendar`, `drive`, `tasks`, `sheets`, `people`,
+  `github`, `search`, `webFetch`).
+- The **MITM proxy** is a separate listener inside the same process. Its
+  job is to terminate TLS for known/intercepted hosts and forward the
+  decrypted HTTP request to the mock server.
+- `eval $(fws server env)` exports `HTTPS_PROXY`, `HTTP_PROXY`, and
+  `SSL_CERT_FILE` so your subsequent shell commands route through the
+  proxy and trust the proxy's CA.
+
+## What the proxy does on each connection
+
+### HTTPS (CONNECT tunnel)
+
+1. Client opens a TCP connection to the proxy and sends
+   `CONNECT example.com:443 HTTP/1.1`.
+2. The proxy decides whether to **intercept** this host or pass it
+   through to the real internet. (See "Intercept rule" below.)
+3. **Pass-through**: the proxy opens a raw TCP connection to the real
+   `example.com:443`, replies `200 Connection Established`, and stitches
+   the two sockets together. After this point the proxy doesn't see the
+   bytes — TLS is end to end with the real server.
+4. **Intercept**: the proxy mints a server certificate for `example.com`
+   on the fly (signed by fws's local CA), terminates TLS itself, then
+   reads the inner HTTP request out of the TLS socket and forwards it
+   over a fresh `http://localhost:<mockPort>/...` connection to the
+   mock server. The proxy attaches two custom headers on this forward,
+   described in the next section.
+5. Multiple HTTP/1.1 requests on the same TLS socket are supported (the
+   proxy doesn't close the socket after one response — see #7 / mitm
+   keep-alive).
+
+### Plain HTTP
+
+1. Client sends the request directly to the proxy with an absolute URL
+   in the request line: `GET http://example.com/foo HTTP/1.1`.
+2. Same intercept-or-passthrough decision as CONNECT.
+3. **Pass-through**: forward to the real `example.com:80` over a normal
+   `http.request` and stream the response back unchanged.
+4. **Intercept**: same as the HTTPS intercept path — forward to the
+   mock server with the custom headers.
+
+### The intercept rule
+
+```
+intercept(host) =
+       host is in the built-in service allowlist
+    OR host has at least one Web Fetch fixture in the store
+```
+
+The built-in allowlist lives in `src/proxy/intercepted-hosts.ts` and is
+the set of hosts where fws ships a dedicated mock service:
+
+- `gmail.googleapis.com`, `www.googleapis.com`, `tasks.googleapis.com`,
+  `sheets.googleapis.com`, `people.googleapis.com`, `chat.googleapis.com`,
+  `docs.googleapis.com`, `slides.googleapis.com`, etc.
+- `api.github.com`
+
+The Web Fetch check is dynamic: any time a user runs `fws fetch add` (or
+the proxy starts up with seeded fixtures), every fixture's host becomes
+eligible for interception. So adding a fixture for
+`https://my-api.test/foo` automatically intercepts any future request to
+`my-api.test`.
+
+Hosts that match neither rule are passed through to the real internet.
+This is intentional — fws isn't trying to be a totalizing sandbox by
+default. If you want full agent isolation, every host the agent reaches
+needs to have either a built-in mock or a Web Fetch fixture.
+
+## What the mock server sees
+
+When the proxy forwards an intercepted request, it doesn't just hand the
+mock server the path — it also tells the mock which host the original
+request was for, via two custom HTTP headers:
+
+```
+GET /gmail/v1/users/me/profile HTTP/1.1
+Host: localhost:4100                       ← rewritten so Express is happy
+X-Fws-Original-Host: gmail.googleapis.com  ← the host the client typed
+X-Fws-Original-Scheme: https               ← whether it was http or https
+Authorization: Bearer fake
+...
+```
+
+`X-Fws-Original-Host` and `X-Fws-Original-Scheme` are fws-specific
+headers (the `X-` prefix is the conventional marker for non-standard
+custom headers). They exist because Express routes the request based on
+path alone, so without these markers the mock server has no way to
+distinguish between, say, `gmail.googleapis.com/foo` and
+`my-api.test/foo`. The Web Fetch lookup needs the original host to
+reconstruct the canonical URL.
+
+These headers are only ever set by the MITM proxy. A direct test fetch
+against the mock server (e.g., `h.fetch('/gmail/v1/users/me/profile')`
+in a unit test) carries no such header, and the routing layer treats it
+as a non-proxied request.
+
+## How the mock server picks a handler
+
+```
+incoming request
+       │
+       ▼
+┌───────────────────────────────────────────┐
+│ webFetchHostDispatcher (runs FIRST)       │
+│                                           │
+│ X-Fws-Original-Host header?               │
+│   ├─ no  → next() (normal routing)        │
+│   ├─ yes, allowlisted host                │
+│   │       (gmail.googleapis.com etc.)     │
+│   │       → next() (let service routes    │
+│   │                  handle it)           │
+│   └─ yes, foreign host (my-api.test)      │
+│           → straight to webFetchCatchAll  │
+└───────────────────────────────────────────┘
+       │
+       ▼  (only if dispatcher called next())
+┌──────────────────────────────┐
+│ Service routes               │
+│   gmailRoutes()              │
+│   calendarRoutes()           │
+│   driveRoutes()              │
+│   tasksRoutes()              │
+│   sheetsRoutes()             │
+│   peopleRoutes()             │
+│   githubRoutes()             │
+│   searchRoutes()             │
+│   webFetchRoutes()           │
+└──────────────────────────────┘
+       │
+       ▼  (only if no service route matched)
+┌──────────────────────────────┐
+│ Express default 404          │
+└──────────────────────────────┘
+```
+
+The dispatcher is the small but important piece that prevents
+**path collisions**. Without it, a fixture for
+`https://random.test/gmail/v1/users/me/profile` would be silently
+shadowed by the gmail route, because Express would match the path
+`/gmail/v1/users/me/profile` against the gmail route before the Web
+Fetch handler ever ran. With the dispatcher in front, foreign-host
+requests are handed to Web Fetch immediately and the gmail route never
+gets a chance to swallow them.
+
+The flip side: requests for **allowlisted** service hosts (the real
+APIs that fws ships dedicated mocks for) still go to their service
+routes. A proxied request for `gmail.googleapis.com/gmail/v1/users/me/profile`
+is handled by `gmailRoutes()`, not by Web Fetch. This is the intended
+behavior — fws's dedicated mocks know how to return the right shape
+of response for those specific APIs.
+
+## What the Web Fetch handler does
+
+When the dispatcher hands a request to `webFetchCatchAll`, the handler:
+
+1. Reconstructs the canonical URL:
+   `${X-Fws-Original-Scheme}://${X-Fws-Original-Host}${req.originalUrl}`
+2. Looks up a fixture, in order:
+   - Exact URL match (with optional method filter)
+   - Host-only match (any path on this host)
+3. If a fixture matches, writes its `{status, headers, body}` to the
+   Express response and returns.
+4. If nothing matches, falls back to a hardcoded default response
+   (`200 application/json`, `{"mock": true, "source": "fws-web-fetch-default"}`).
+   The default is intentionally not user-configurable; if you want
+   a specific response for a specific URL, add a fixture for it.
+
+## Example walkthroughs
+
+### 1. `gws gmail users messages list`
+
+```
+gws gmail users messages list
+   │
+   │ HTTPS to gmail.googleapis.com:443
+   ▼
+MITM proxy CONNECT
+   │
+   │ host = gmail.googleapis.com → in allowlist → intercept
+   │ TLS termination, parse HTTP request
+   ▼
+Forward to mock server with:
+   X-Fws-Original-Host: gmail.googleapis.com
+   X-Fws-Original-Scheme: https
+   ▼
+Dispatcher: header present, host is allowlisted → next()
+   ▼
+gmailRoutes() matches `/gmail/v1/users/me/messages` → returns seed messages
+```
+
+### 2. `curl https://example.com/` (with the seeded Web Fetch fixture)
+
+```
+curl https://example.com/
+   │
+   │ HTTPS_PROXY → CONNECT example.com:443
+   ▼
+MITM proxy CONNECT
+   │
+   │ host = example.com → not in allowlist
+   │ but example.com has a fixture → intercept
+   │ TLS termination, parse HTTP request
+   ▼
+Forward to mock server with:
+   X-Fws-Original-Host: example.com
+   X-Fws-Original-Scheme: https
+   ▼
+Dispatcher: header present, host NOT in allowlist → straight to webFetchCatchAll
+   ▼
+Lookup fixture for https://example.com/ → seeded HTML "Example Domain (mocked)"
+```
+
+### 3. `curl https://random.test/gmail/v1/users/me/profile` (path collision)
+
+```
+fws fetch add --url https://random.test/gmail/v1/users/me/profile --body '{"custom":"yes"}'
+curl https://random.test/gmail/v1/users/me/profile
+   │
+   │ HTTPS_PROXY → CONNECT random.test:443
+   ▼
+MITM proxy CONNECT
+   │
+   │ host = random.test → not in allowlist
+   │ but random.test has a fixture → intercept
+   ▼
+Forward to mock server with:
+   X-Fws-Original-Host: random.test
+   ▼
+Dispatcher: header present, host NOT in allowlist → straight to webFetchCatchAll
+   │  (the gmailRoutes() never sees this request)
+   ▼
+Lookup fixture for https://random.test/gmail/v1/users/me/profile → returns {"custom":"yes"}
+```
+
+### 4. `curl https://nothing-real.invalid/` (no fixture, no allowlist)
+
+```
+curl https://nothing-real.invalid/
+   │
+   │ HTTPS_PROXY → CONNECT nothing-real.invalid:443
+   ▼
+MITM proxy CONNECT
+   │
+   │ host = nothing-real.invalid → not in allowlist, no fixture → passthrough
+   │ Open raw TCP to the real nothing-real.invalid:443
+   ▼
+DNS resolution fails (or real server unreachable)
+   ▼
+curl gets a connection error — there is no mock for this host
+```
+
+If you want this case to return a mock instead of failing, add a fixture
+or a host-only fixture: `fws fetch add --host nothing-real.invalid --body '...'`.
+
+## Adding a new fake service that plays nice with the proxy
+
+Three things to remember:
+
+1. **Add the host(s) to `INTERCEPTED_HOSTS`** in
+   `src/proxy/intercepted-hosts.ts`. The proxy needs to know it should
+   terminate TLS for those hosts; otherwise traffic to them passes
+   through to the real internet.
+2. **Mount your router in `src/server/app.ts`** alongside the existing
+   `gmailRoutes()`, `calendarRoutes()`, etc. The order doesn't matter
+   between siblings as long as their paths don't overlap. Make sure
+   you're mounted **after** `webFetchHostDispatcher` so dispatcher gets
+   the first look at every request.
+3. **Don't read `X-Fws-Original-Host` from inside your route**. The
+   dispatcher already used it to decide that your route should run; by
+   the time the request reaches your handler, the host is implicitly
+   "an allowlisted service host". If you genuinely need to discriminate
+   by host inside the same router, you have two options: either
+   register multiple sub-routers (one per host) or read the header
+   yourself, but the simpler thing is usually to put each host in its
+   own router file.

--- a/src/proxy/intercepted-hosts.ts
+++ b/src/proxy/intercepted-hosts.ts
@@ -1,0 +1,35 @@
+/**
+ * Hosts that the MITM proxy intercepts unconditionally because there is a
+ * dedicated mock service mounted for them in src/server/routes/. Shared
+ * between mitm.ts (which uses the list to decide what to intercept) and
+ * the route layer (which uses it to decide whether an intercepted request
+ * should go to a service route or to the Web Fetch catch-all).
+ *
+ * Lives in its own file to avoid a circular import: routes/fetch.ts and
+ * mitm.ts already reference each other (mitm imports `hasFixtureForHost`
+ * from routes/fetch), so the shared list cannot live in either of them.
+ */
+export const INTERCEPTED_HOSTS: readonly string[] = [
+  // Google Workspace
+  'gmail.googleapis.com',
+  'www.googleapis.com',
+  'tasks.googleapis.com',
+  'workspaceevents.googleapis.com',
+  'docs.googleapis.com',
+  'slides.googleapis.com',
+  'chat.googleapis.com',
+  'classroom.googleapis.com',
+  'forms.googleapis.com',
+  'keep.googleapis.com',
+  'meet.googleapis.com',
+  'people.googleapis.com',
+  'sheets.googleapis.com',
+  'admin.googleapis.com',
+  // GitHub
+  'api.github.com',
+];
+
+/** True when `hostname` is one of the built-in service hosts (or a subdomain of one). */
+export function isAllowlistedHost(hostname: string): boolean {
+  return INTERCEPTED_HOSTS.some(h => hostname === h || hostname.endsWith('.' + h));
+}

--- a/src/proxy/mitm.ts
+++ b/src/proxy/mitm.ts
@@ -5,26 +5,7 @@ import crypto from 'node:crypto';
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import { hasFixtureForHost } from '../server/routes/fetch.js';
-
-const INTERCEPTED_HOSTS = [
-  // Google Workspace
-  'gmail.googleapis.com',
-  'www.googleapis.com',
-  'tasks.googleapis.com',
-  'workspaceevents.googleapis.com',
-  'docs.googleapis.com',
-  'slides.googleapis.com',
-  'chat.googleapis.com',
-  'classroom.googleapis.com',
-  'forms.googleapis.com',
-  'keep.googleapis.com',
-  'meet.googleapis.com',
-  'people.googleapis.com',
-  'sheets.googleapis.com',
-  'admin.googleapis.com',
-  // GitHub
-  'api.github.com',
-];
+import { isAllowlistedHost } from './intercepted-hosts.js';
 
 interface CertPair {
   key: string;
@@ -140,10 +121,6 @@ async function getHostCert(hostname: string): Promise<CertPair> {
   const pair = { key: keyPem, cert: certPem };
   hostCerts.set(hostname, pair);
   return pair;
-}
-
-function isAllowlistedHost(hostname: string): boolean {
-  return INTERCEPTED_HOSTS.some(h => hostname === h || hostname.endsWith('.' + h));
 }
 
 /**

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -7,7 +7,7 @@ import { sheetsRoutes } from './routes/sheets.js';
 import { peopleRoutes } from './routes/people.js';
 import { githubRoutes } from './routes/github.js';
 import { searchRoutes } from './routes/search.js';
-import { webFetchRoutes, webFetchCatchAll } from './routes/fetch.js';
+import { webFetchRoutes, webFetchHostDispatcher } from './routes/fetch.js';
 import { controlRoutes } from './routes/control.js';
 import { errorHandler } from './middleware.js';
 
@@ -16,6 +16,17 @@ export function createApp(): express.Express {
   app.use(express.json({ limit: '10mb' }));
 
   app.use(controlRoutes());
+
+  // Web Fetch host dispatcher runs BEFORE the service routes. For
+  // requests forwarded by the MITM proxy with X-Fws-Original-Host set to
+  // a non-allowlisted host (i.e. an arbitrary host that only got
+  // intercepted because the user added a Web Fetch fixture for it), it
+  // hands the request straight to the Web Fetch catch-all so a fixture
+  // for `https://random.test/gmail/v1/...` doesn't get shadowed by the
+  // gmail route. Requests for allowlisted service hosts and direct test
+  // fetches fall through to the normal routing chain unchanged.
+  app.use(webFetchHostDispatcher());
+
   app.use(gmailRoutes());
   app.use(calendarRoutes());
   app.use(driveRoutes());
@@ -25,11 +36,6 @@ export function createApp(): express.Express {
   app.use(githubRoutes());
   app.use(searchRoutes());
   app.use(webFetchRoutes());
-
-  // Web Fetch catch-all must be last (before errorHandler) so it only
-  // intercepts requests that no real route handled. Limited to requests
-  // that arrived via the MITM proxy by checking X-Fws-Original-Host.
-  app.use(webFetchCatchAll());
 
   app.use(errorHandler);
 

--- a/src/server/routes/fetch.ts
+++ b/src/server/routes/fetch.ts
@@ -1,6 +1,7 @@
 import { Router, type RequestHandler } from 'express';
 import { getStore } from '../../store/index.js';
 import type { WebFetchFixture, WebFetchResponse } from '../../store/types.js';
+import { isAllowlistedHost } from '../../proxy/intercepted-hosts.js';
 
 /**
  * Web Fetch — generic HTTP/HTTPS mocking for arbitrary URLs.
@@ -85,11 +86,44 @@ export function webFetchRoutes(): Router {
 }
 
 /**
- * Catch-all middleware. Registered AFTER all the explicit service routes.
- * When the MITM proxy intercepts a host and forwards it here with
- * `X-Fws-Original-Host`, this responds with a fixture (or the hardcoded
- * default). Requests without that header are direct test fetches and
- * fall through to Express's default 404.
+ * Runs BEFORE the service routes (gmail/calendar/...). Looks at
+ * X-Fws-Original-Host on incoming requests and decides who should handle
+ * them:
+ *
+ *   - header absent: in-process test or some other direct call. Fall
+ *     through to normal routing; if nothing matches we end up at the
+ *     default 404 handler. (No change vs. before this dispatcher existed.)
+ *
+ *   - header present and points at a built-in service host
+ *     (gmail.googleapis.com, api.github.com, ...): the request really is
+ *     for one of the mocked services. Fall through so the matching
+ *     service route handles it.
+ *
+ *   - header present and points at any other host: the only reason that
+ *     host got intercepted is because there's a Web Fetch fixture for it.
+ *     Skip the service routes entirely and go straight to the Web Fetch
+ *     handler — otherwise a fixture for `https://random.test/gmail/v1/...`
+ *     would be silently shadowed by the gmail route just because the
+ *     paths happen to overlap.
+ *
+ * Mounted in app.ts BEFORE all service routes for that exact reason.
+ */
+export function webFetchHostDispatcher(): RequestHandler {
+  const catchAll = webFetchCatchAll();
+  return (req, res, next) => {
+    const originalHost = req.header('x-fws-original-host');
+    if (!originalHost) return next();
+    if (isAllowlistedHost(originalHost)) return next();
+    return catchAll(req, res, next);
+  };
+}
+
+/**
+ * Catch-all handler used by `webFetchHostDispatcher` (and previously
+ * registered as a final-fallback in app.ts). Reconstructs the canonical
+ * URL from `X-Fws-Original-Host` + `X-Fws-Original-Scheme` + the path,
+ * runs a fixture lookup, and writes the matched response. If no fixture
+ * matches we fall back to the hardcoded default response.
  */
 export function webFetchCatchAll(): RequestHandler {
   return (req, res, next) => {

--- a/test/e2e/fetch.e2e.test.ts
+++ b/test/e2e/fetch.e2e.test.ts
@@ -104,4 +104,35 @@ describe('e2e: Web Fetch through real proxy', () => {
       expect(data.mock).toBe(true);
     });
   });
+
+  describe('Path collision regression (gh#15)', () => {
+    it('foreign-host fixture wins over a colliding service-route path', async () => {
+      // Register a fixture for a foreign host whose path happens to
+      // collide with the gmail route. Without the host dispatcher, the
+      // gmail route would shadow the fixture.
+      await h.fetch('/__fws/setup/fetch/fixture', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          url: 'https://collision.test/gmail/v1/users/me/profile',
+          response: {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+            body: JSON.stringify({ source: 'fixture-not-gmail' }),
+          },
+        }),
+      });
+
+      const { stdout, stderr, exitCode } = await h.run('curl', [
+        '-sf',
+        '--proxy', `http://localhost:${h.proxyPort}`,
+        '--cacert', h.caPath,
+        'https://collision.test/gmail/v1/users/me/profile',
+      ]);
+      expect(exitCode, `curl stderr: ${stderr}`).toBe(0);
+      const data = JSON.parse(stdout);
+      expect(data.source).toBe('fixture-not-gmail');
+      expect(data.emailAddress).toBeUndefined();
+    });
+  });
 });

--- a/test/fetch.test.ts
+++ b/test/fetch.test.ts
@@ -147,17 +147,67 @@ describe('Web Fetch (generic HTTP/HTTPS mock)', () => {
       expect(data.source).toBe('fws-web-fetch-default');
     });
 
-    it('does NOT shadow real routes when intercepted host happens to match an existing path', async () => {
-      // Even with the original-host header set, if a real route matches
-      // the path, that route still wins (the catch-all only fires when no
-      // other route handled the request). This is the known path-collision
-      // limitation; documented separately.
+    it('allowlisted service host: real service route still handles the request', async () => {
+      // www.googleapis.com is in the built-in service allowlist, so the
+      // dispatcher lets it fall through to the normal routing chain and
+      // the search route handles it. This is the desirable behavior — a
+      // proxied gmail / search / github request should be served by its
+      // dedicated mock, not by the Web Fetch catch-all.
       const res = await h.fetch('/customsearch/v1?q=python&cx=abc', {
         headers: { 'x-fws-original-host': 'www.googleapis.com' },
       });
       expect(res.status).toBe(200);
       const data = await res.json();
       expect(data.kind).toBe('customsearch#search');
+    });
+
+    it('foreign host: fixture wins on path collision with a real service route (gh#15)', async () => {
+      // Regression for gh#15. Without the host dispatcher, this fixture
+      // would be shadowed by the gmail route because the path matches.
+      // With the dispatcher, the proxy header `random.test` is recognized
+      // as a foreign host and the request goes straight to Web Fetch.
+      await h.fetch('/__fws/setup/fetch/fixture', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          url: 'https://random.test/gmail/v1/users/me/profile',
+          response: {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+            body: JSON.stringify({ custom: 'yes', source: 'fixture' }),
+          },
+        }),
+      });
+
+      const res = await h.fetch('/gmail/v1/users/me/profile', {
+        headers: {
+          'x-fws-original-host': 'random.test',
+          'x-fws-original-scheme': 'https',
+        },
+      });
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.custom).toBe('yes');
+      expect(data.source).toBe('fixture');
+      // Crucially, NOT the seeded gmail profile (testuser@example.com)
+      expect(data.emailAddress).toBeUndefined();
+    });
+
+    it('foreign host with no fixture for the path: hardcoded default fires (not the service route)', async () => {
+      // Even when the path collides with a real service route, a foreign
+      // host with no specific fixture for that path gets the Web Fetch
+      // default response, NOT the service route's mock data.
+      // (example.com is seeded with a host-only fixture, so any path on
+      // example.com gets the default unless a more specific fixture exists.)
+      const res = await h.fetch('/gmail/v1/users/me/profile', {
+        headers: {
+          'x-fws-original-host': 'totally.unrelated.test',
+          'x-fws-original-scheme': 'https',
+        },
+      });
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.source).toBe('fws-web-fetch-default');
     });
   });
 });


### PR DESCRIPTION
Fixes #15.

## What was broken

```bash
fws server start
fws fetch add --url 'https://random.test/gmail/v1/users/me/profile' --body '{"custom":"yes"}'
curl --proxy http://localhost:4101 --cacert ~/.local/share/fws/certs/ca.crt \
  https://random.test/gmail/v1/users/me/profile
```

**Expected**: `{"custom":"yes"}`.
**Actual**: the seeded gmail profile (`testuser@example.com` JSON).

The gmail route matched the path `/gmail/v1/users/me/profile` before the Web Fetch handler ever saw the request. The route doesn't look at `X-Fws-Original-Host`, so it had no idea the request was actually for `random.test`.

## Fix

A new request-handler runs **before** the service routes and looks at `X-Fws-Original-Host`:

| `X-Fws-Original-Host` | Action |
|---|---|
| absent (direct test fetch) | `next()` → normal routing |
| allowlisted service host (`gmail.googleapis.com`, `api.github.com`, ...) | `next()` → service routes handle it |
| foreign host (with a Web Fetch fixture) | go straight to Web Fetch — service routes never see it |

Three small pieces:

1. **`src/proxy/intercepted-hosts.ts`** (new) — pulls `INTERCEPTED_HOSTS` and `isAllowlistedHost()` out of `mitm.ts` into a shared module so both the proxy AND the route layer can use the same allowlist (without creating a circular import).
2. **`src/server/routes/fetch.ts`** — new `webFetchHostDispatcher()` that implements the table above.
3. **`src/server/app.ts`** — registers the dispatcher BEFORE service routes; removes the now-redundant final `webFetchCatchAll()` registration (the dispatcher calls it directly when needed).

## Side-effect (intentional)

Requests for an **allowlisted** service host that hit a path no service route knows about used to fall through to the Web Fetch default response. They now return Express's default 404 instead. This is the more accurate behavior — the dedicated mock is the source of truth for those hosts; an unknown path means "this endpoint isn't mocked", and that should look like a real 404 rather than a generic mock placeholder.

## Tests

- **`test/fetch.test.ts`** — 2 new unit tests:
  - `foreign host: fixture wins on path collision with a real service route (gh#15)` — direct regression for the bug
  - `foreign host with no fixture for the path: hardcoded default fires` — sanity that foreign-host requests still get the Web Fetch default, not service-route data
  - The existing `does NOT shadow real routes...` test was renamed to `allowlisted service host: real service route still handles the request` to make its intent clearer (allowlisted hosts STILL go to service routes — that part is unchanged)
- **`test/e2e/fetch.e2e.test.ts`** — 1 new e2e: same collision scenario but driven through real `curl` + the daemon's MITM proxy

Both new unit tests fail against the pre-fix `app.ts` (verified by temporarily reverting). 232 tests pass locally.

## Docs

New **`docs/proxy.md`** walks through the entire forwarding pipeline in plain English:

- The actors (curl/gh/gws → MITM proxy → mock server)
- HTTPS CONNECT vs plain HTTP
- The intercept rule (built-in allowlist + Web Fetch fixtures)
- What headers the proxy adds (`X-Fws-Original-Host`, `X-Fws-Original-Scheme`) and why
- How the mock server picks a handler (the new dispatcher)
- Four worked example walkthroughs:
  1. `gws gmail users messages list` (allowlisted host)
  2. `curl https://example.com/` (seeded fixture)
  3. The collision scenario (foreign host, fixture wins)
  4. `curl https://nothing-real.invalid/` (no fixture, no allowlist → real-network passthrough)
- A short "adding a new fake service" checklist

Linked from `README.md` under Documentation.

## Test plan
- [ ] PR `unit` job green
- [ ] PR `e2e` job green
- [ ] After merge: the gh#15 repro returns the fixture body instead of gmail seed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
