### PR TITLE
feat: fetch fixture upsert + reset endpoint

### DIFF
--- a/src/server/routes/control.ts
+++ b/src/server/routes/control.ts
@@ -132,6 +132,13 @@ export function controlRoutes(): Router {
     res.json({ id });
   });
 
+  // Clear only web fetch fixtures (preserves gmail/calendar/drive/etc.)
+  r.post('/__fws/setup/fetch/reset', (_req, res) => {
+    const store = getStore();
+    store.webFetch.fixtures = [];
+    res.json({ status: 'reset', scope: 'webFetch' });
+  });
+
   return r;
 }
 

--- a/src/server/routes/fetch.ts
+++ b/src/server/routes/fetch.ts
@@ -79,8 +79,17 @@ export function webFetchRoutes(): Router {
         bodyEncoding: body.response.bodyEncoding,
       },
     };
-    store.webFetch.fixtures.push(fixture);
-    res.json({ status: 'added', count: store.webFetch.fixtures.length });
+    // Upsert: replace existing fixture with same URL/host+method, otherwise append.
+    const idx = store.webFetch.fixtures.findIndex(f =>
+      (fixture.url && f.url === fixture.url && (f.method ?? '') === (fixture.method ?? '')) ||
+      (fixture.host && !fixture.url && f.host === fixture.host && !f.url && (f.method ?? '') === (fixture.method ?? '')),
+    );
+    if (idx >= 0) {
+      store.webFetch.fixtures[idx] = fixture;
+    } else {
+      store.webFetch.fixtures.push(fixture);
+    }
+    res.json({ status: idx >= 0 ? 'replaced' : 'added', count: store.webFetch.fixtures.length });
   });
 
   return r;

--- a/src/server/routes/fetch.ts
+++ b/src/server/routes/fetch.ts
@@ -76,6 +76,7 @@ export function webFetchRoutes(): Router {
         status: body.response.status,
         headers: body.response.headers,
         body: body.response.body,
+        bodyEncoding: body.response.bodyEncoding,
       },
     };
     store.webFetch.fixtures.push(fixture);
@@ -143,7 +144,10 @@ export function webFetchCatchAll(): RequestHandler {
         res.setHeader(k, v);
       }
     }
-    res.status(response.status).send(response.body);
+    const payload = response.bodyEncoding === 'base64'
+      ? Buffer.from(response.body, 'base64')
+      : response.body;
+    res.status(response.status).send(payload);
   };
 }
 

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -368,4 +368,6 @@ export interface WebFetchResponse {
   headers?: Record<string, string>;
   /** Response body as a string. Use base64 + a Content-Encoding/Content-Type header for binary. */
   body: string;
+  /** When set to 'base64', the body is base64-encoded and will be decoded to a Buffer before sending. */
+  bodyEncoding?: 'base64';
 }

--- a/test/fetch.test.ts
+++ b/test/fetch.test.ts
@@ -67,6 +67,48 @@ describe('Web Fetch (generic HTTP/HTTPS mock)', () => {
       expect(JSON.parse(data.response.body).injected).toBe(true);
     });
 
+    it('round-trips a base64-encoded binary fixture through the catch-all', async () => {
+      // 4 bytes of binary data that aren't valid UTF-8
+      const binaryBuf = Buffer.from([0x00, 0x01, 0xff, 0xfe]);
+      const b64 = binaryBuf.toString('base64');
+
+      const setup = await h.fetch('/__fws/setup/fetch/fixture', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          url: 'https://binary.test/image.png',
+          response: {
+            status: 200,
+            headers: { 'content-type': 'image/png' },
+            body: b64,
+            bodyEncoding: 'base64',
+          },
+        }),
+      });
+      expect(setup.status).toBe(200);
+
+      // Direct API returns the raw fixture metadata (body stays base64)
+      const meta = await h.fetch(
+        '/__fws/fetch?url=' + encodeURIComponent('https://binary.test/image.png'),
+      );
+      const metaData = await meta.json();
+      expect(metaData.matched).toBe('url');
+      expect(metaData.response.bodyEncoding).toBe('base64');
+      expect(metaData.response.body).toBe(b64);
+
+      // Catch-all (proxy path) decodes to real binary
+      const res = await h.fetch('/image.png', {
+        headers: {
+          'x-fws-original-host': 'binary.test',
+          'x-fws-original-scheme': 'https',
+        },
+      });
+      expect(res.status).toBe(200);
+      expect(res.headers.get('content-type')).toBe('image/png');
+      const arrayBuf = await res.arrayBuffer();
+      expect(Buffer.from(arrayBuf)).toEqual(binaryBuf);
+    });
+
     it('rejects fixtures missing url and host', async () => {
       const res = await h.fetch('/__fws/setup/fetch/fixture', {
         method: 'POST',


### PR DESCRIPTION
## Summary

- **base64 body encoding** for `WebFetchResponse`: add optional `bodyEncoding: 'base64'` field so fixtures can carry binary payloads (e.g., PNG images). The catch-all handler decodes base64 to Buffer before sending.
- **Upsert semantics** for `POST /__fws/setup/fetch/fixture`: when a fixture with the same URL+method already exists, it gets replaced instead of appending a duplicate.
- **New endpoint** `POST /__fws/setup/fetch/reset`: clears only web fetch fixtures while preserving gmail/calendar/drive/tasks/sheets/people/github state.

Closes #18

## Test plan

- [x] Existing tests pass + new base64 round-trip test added (233 → 234 tests)
- [x] Manual verification in Docker container:
  - Reset clears fixtures, returns `{ status: "reset", scope: "webFetch" }`
  - Add creates fixture, returns `{ status: "added", count: N }`
  - Upsert replaces existing, returns `{ status: "replaced", count: N }`
  - Proxy serves updated content after upsert
  - Binary (base64) fixtures served correctly through proxy

🤖 Generated with [Claude Code](https://claude.com/claude-code)