### PR TITLE
fix: bundle system CAs for passthrough TLS verification

### DIFF
--- a/bin/fws.ts
+++ b/bin/fws.ts
@@ -67,7 +67,7 @@ serverCmd
       await generateConfigDir(port, configDir);
 
       // Generate CA cert for MITM proxy
-      const { caPath } = await generateCACert(getDataDir());
+      const { caPath, bundlePath } = await generateCACert(getDataDir());
 
       const app = createApp();
       const server: Server = await new Promise((resolve) => {
@@ -80,7 +80,7 @@ serverCmd
 
       await ensureDir(getDataDir());
       await fs.writeFile(getServerInfoPath(), JSON.stringify({
-        port, proxyPort, pid: process.pid, caPath,
+        port, proxyPort, pid: process.pid, caPath, bundlePath,
       }));
 
       const shutdown = () => {
@@ -144,7 +144,7 @@ serverCmd
       // Read server info to get caPath and proxyPort
       const serverInfo = JSON.parse(await fs.readFile(getServerInfoPath(), 'utf-8').catch(() => '{}'));
       const proxyPort = serverInfo.proxyPort || port + 1;
-      const caPath = serverInfo.caPath || path.join(getDataDir(), 'certs', 'ca.crt');
+      const bundlePath = serverInfo.bundlePath || path.join(getDataDir(), 'certs', 'ca-bundle.crt');
 
       console.log(`fws server started on port ${port} (pid ${child.pid})\n`);
       console.log(`Run this to configure your shell:\n`);
@@ -153,7 +153,7 @@ serverCmd
       console.log(`  export GOOGLE_WORKSPACE_CLI_CONFIG_DIR=${configDir}`);
       console.log(`  export GOOGLE_WORKSPACE_CLI_TOKEN=fake`);
       console.log(`  export HTTPS_PROXY=http://localhost:${proxyPort}`);
-      console.log(`  export SSL_CERT_FILE=${caPath}`);
+      console.log(`  export SSL_CERT_FILE=${bundlePath}`);
       console.log(`  export GH_TOKEN=fake`);
       console.log(`  export GH_REPO=testuser/my-project\n`);
       console.log(`Then try:\n`);
@@ -192,13 +192,13 @@ serverCmd
     try {
       const info = JSON.parse(await fs.readFile(getServerInfoPath(), 'utf-8'));
       const configDir = path.join(getDataDir(), 'config');
-      const caPath = info.caPath || path.join(getDataDir(), 'certs', 'ca.crt');
+      const bundlePath = info.bundlePath || path.join(getDataDir(), 'certs', 'ca-bundle.crt');
       const proxyPort = info.proxyPort || info.port + 1;
 
       console.log(`export GOOGLE_WORKSPACE_CLI_CONFIG_DIR=${configDir}`);
       console.log(`export GOOGLE_WORKSPACE_CLI_TOKEN=fake`);
       console.log(`export HTTPS_PROXY=http://localhost:${proxyPort}`);
-      console.log(`export SSL_CERT_FILE=${caPath}`);
+      console.log(`export SSL_CERT_FILE=${bundlePath}`);
       console.log(`export GH_TOKEN=fake`);
       console.log(`export GH_REPO=testuser/my-project`);
     } catch {

--- a/src/proxy/mitm.ts
+++ b/src/proxy/mitm.ts
@@ -31,12 +31,27 @@ function generateCA(): CertPair {
   };
 }
 
-export async function generateCACert(dataDir: string): Promise<{ caPath: string; keyPath: string }> {
+// Well-known system CA bundle locations (checked in order).
+const SYSTEM_CA_PATHS = [
+  '/etc/ssl/certs/ca-certificates.crt',   // Debian/Ubuntu/Arch
+  '/etc/pki/tls/certs/ca-bundle.crt',     // RHEL/Fedora
+  '/etc/ssl/cert.pem',                     // Alpine/macOS
+];
+
+async function findSystemCABundle(): Promise<string | null> {
+  for (const p of SYSTEM_CA_PATHS) {
+    try { await fs.access(p); return p; } catch {}
+  }
+  return null;
+}
+
+export async function generateCACert(dataDir: string): Promise<{ caPath: string; keyPath: string; bundlePath: string }> {
   const certDir = path.join(dataDir, 'certs');
   await fs.mkdir(certDir, { recursive: true });
 
   const caPath = path.join(certDir, 'ca.crt');
   const keyPath = path.join(certDir, 'ca.key');
+  const bundlePath = path.join(certDir, 'ca-bundle.crt');
 
   // Check if CA already exists
   try {
@@ -46,24 +61,32 @@ export async function generateCACert(dataDir: string): Promise<{ caPath: string;
       cert: await fs.readFile(caPath, 'utf-8'),
       key: await fs.readFile(keyPath, 'utf-8'),
     };
-    return { caPath, keyPath };
-  } catch {}
+  } catch {
+    // Generate new CA using openssl
+    const { execFileSync } = await import('node:child_process');
+    execFileSync('openssl', [
+      'req', '-x509', '-newkey', 'rsa:2048',
+      '-keyout', keyPath, '-out', caPath,
+      '-days', '3650', '-nodes',
+      '-subj', '/CN=fws-mock-ca',
+    ], { stdio: 'pipe' });
 
-  // Generate new CA using openssl
-  const { execFileSync } = await import('node:child_process');
-  execFileSync('openssl', [
-    'req', '-x509', '-newkey', 'rsa:2048',
-    '-keyout', keyPath, '-out', caPath,
-    '-days', '3650', '-nodes',
-    '-subj', '/CN=fws-mock-ca',
-  ], { stdio: 'pipe' });
+    caCert = {
+      cert: await fs.readFile(caPath, 'utf-8'),
+      key: await fs.readFile(keyPath, 'utf-8'),
+    };
+  }
 
-  caCert = {
-    cert: await fs.readFile(caPath, 'utf-8'),
-    key: await fs.readFile(keyPath, 'utf-8'),
-  };
+  // Build a combined bundle: FWS CA + system CAs, so that passthrough
+  // hosts (real internet) can be verified alongside MITM-intercepted ones.
+  const systemCA = await findSystemCABundle();
+  const parts = [caCert.cert.trimEnd()];
+  if (systemCA) {
+    parts.push(await fs.readFile(systemCA, 'utf-8'));
+  }
+  await fs.writeFile(bundlePath, parts.join('\n'));
 
-  return { caPath, keyPath };
+  return { caPath, keyPath, bundlePath };
 }
 
 async function getHostCert(hostname: string): Promise<CertPair> {

--- a/test/e2e/fetch.e2e.test.ts
+++ b/test/e2e/fetch.e2e.test.ts
@@ -90,6 +90,25 @@ describe('e2e: Web Fetch through real proxy', () => {
       // NOT get a mocked response back.
       expect(exitCode).not.toBe(0);
     });
+
+    it('passthrough TLS verification succeeds with ca-bundle (real host)', async () => {
+      // The ca-bundle.crt includes system CAs, so passthrough to real
+      // HTTPS hosts should pass TLS verification. We hit a public
+      // endpoint that always responds without needing an API key.
+      const { stdout, exitCode } = await h.run('curl', [
+        '-s',
+        '-o', '/dev/null',
+        '-w', '%{http_code}',
+        '--max-time', '5',
+        '--proxy', `http://localhost:${h.proxyPort}`,
+        '--cacert', h.caPath,
+        'https://api.openai.com/v1/models',
+      ]);
+      // 401 (no API key) proves TLS handshake succeeded — the request
+      // reached the real server and got an auth error, not a cert error.
+      expect(exitCode).toBe(0);
+      expect(stdout.trim()).toBe('401');
+    });
   });
 
   describe('Plain HTTP', () => {

--- a/test/e2e/helpers/cli-harness.ts
+++ b/test/e2e/helpers/cli-harness.ts
@@ -177,21 +177,24 @@ export async function startFwsDaemon(opts: StartOptions = {}): Promise<CliHarnes
 
   await waitForHealth(port);
 
-  // Read server.json to discover proxyPort and caPath
+  // Read server.json to discover proxyPort and bundlePath
   const serverInfoPath = path.join(dataDir, 'server.json');
   const info = JSON.parse(await readFile(serverInfoPath, 'utf-8')) as {
     port: number;
     proxyPort: number;
     pid: number;
     caPath: string;
+    bundlePath: string;
   };
+
+  const bundlePath = info.bundlePath || info.caPath;
 
   const proxyEnv: Record<string, string> = {
     FWS_DATA_DIR: dataDir,
     GOOGLE_WORKSPACE_CLI_CONFIG_DIR: configDir,
     GOOGLE_WORKSPACE_CLI_TOKEN: 'fake',
     HTTPS_PROXY: `http://localhost:${info.proxyPort}`,
-    SSL_CERT_FILE: info.caPath,
+    SSL_CERT_FILE: bundlePath,
     GH_TOKEN: 'fake',
     GH_REPO: 'testuser/my-project',
   };
@@ -199,7 +202,7 @@ export async function startFwsDaemon(opts: StartOptions = {}): Promise<CliHarnes
   return {
     port: info.port,
     proxyPort: info.proxyPort,
-    caPath: info.caPath,
+    caPath: bundlePath,
     configDir,
     dataDir,
     proxyEnv,

--- a/test/helpers/harness.ts
+++ b/test/helpers/harness.ts
@@ -37,7 +37,7 @@ export async function createTestHarness(): Promise<TestHarness> {
 
   // MITM proxy for helper commands
   const dataDir = await mkdtemp(path.join(tmpdir(), 'fws-test-data-'));
-  const { caPath } = await generateCACert(dataDir);
+  const { bundlePath } = await generateCACert(dataDir);
   const proxyServer = startMitmProxy(port, 0); // random port
   const proxyPort = (proxyServer.address() as any).port as number;
 
@@ -50,7 +50,7 @@ export async function createTestHarness(): Promise<TestHarness> {
   const proxyEnv = {
     ...baseEnv,
     HTTPS_PROXY: `http://localhost:${proxyPort}`,
-    SSL_CERT_FILE: caPath,
+    SSL_CERT_FILE: bundlePath,
   };
 
   const gwsPath = process.env.GWS_PATH || 'gws';


### PR DESCRIPTION
## Summary
- `SSL_CERT_FILE` pointed only at the FWS mock CA, which broke TLS verification for passthrough hosts (e.g. `api.openai.com`) — their real certificates are signed by system CAs not in the FWS trust store
- Generate a `ca-bundle.crt` that combines the FWS CA with the system CA bundle, and point `SSL_CERT_FILE` at that instead
- Add e2e test for passthrough TLS verification

## Test plan
- [x] All 234 tests pass (233 existing + 1 new)
- [x] New e2e test: passthrough to `api.openai.com` succeeds TLS verification (HTTP 401)
- [x] Fixture hosts (example.com) still work as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)