### PR TITLE
fix(gmail): include Message-ID header in seeded/sent messages

### DIFF
--- a/src/server/routes/control.ts
+++ b/src/server/routes/control.ts
@@ -54,6 +54,7 @@ export function controlRoutes(): Router {
           { name: 'To', value: to || userEmail },
           { name: 'Subject', value: subject || '(no subject)' },
           { name: 'Date', value: now },
+          { name: 'Message-ID', value: `<${id}@example.com>` },
         ],
         body: {
           size: (body || '').length,

--- a/src/server/routes/gmail.ts
+++ b/src/server/routes/gmail.ts
@@ -93,6 +93,7 @@ export function gmailRoutes(): Router {
         { name: 'From', value: store.gmail.profile.emailAddress },
         { name: 'To', value: 'recipient@example.com' },
         { name: 'Subject', value: '(no subject)' },
+        { name: 'Message-ID', value: `<${id}@example.com>` },
       ];
     }
 
@@ -925,6 +926,7 @@ function ingestRawMessage(
       { name: 'From', value: store.gmail.profile.emailAddress },
       { name: 'To', value: 'recipient@example.com' },
       { name: 'Subject', value: '(no subject)' },
+      { name: 'Message-ID', value: `<${id}@example.com>` },
     ];
   }
 


### PR DESCRIPTION
## Summary

Every message-construction path in fws except `src/store/seed.ts` was creating gmail messages without an RFC 5322 `Message-ID` header. Newer gws helpers (0.22.x) reject such messages — `+read`, `+reply`, `+reply-all`, `+forward` all abort with `"Message is missing Message-ID header"` (verified with gws 0.22.5).

Add the header in the three remaining sites so programmatically-seeded and fallback-sent messages round-trip through helper commands.

## Changes

- `src/server/routes/control.ts`: `POST /__fws/setup/gmail/message`.
- `src/server/routes/gmail.ts`: `POST /gmail/v1/users/:userId/messages/send` fallback branch (when `raw` isn't provided).
- `src/server/routes/gmail.ts`: `POST /upload/gmail/v1/users/:userId/messages/send` fallback branch (when `rawBody` is empty).

Each site gets ``{ name: 'Message-ID', value: `<${id}@example.com>` }`` appended to the synthesized headers array, matching the pattern already used in `src/store/seed.ts`.

## Context

`src/store/seed.ts`'s `makeMessage` already carries a Message-ID with an explicit comment acknowledging the gws 0.22.5 behavior. The other three paths were copy-pasted/parallel variants that didn't get the same fix — this PR brings them into line.

## Verification

Before (gws 0.22.5, message seeded via `/__fws/setup/gmail/message`):
```
$ gws gmail +read --id <id> --headers --html
{"error":{"code":500,"message":"Message is missing Message-ID header","reason":"internalError"}}
error: Message is missing Message-ID header
```

After:
```
$ gws gmail +read --id <id> --headers --html
(returns headers + body as expected)
```

End-to-end: with this fix applied, an ADFI e2e test that seeds an attack email into fws and has the agent call `gws gmail +read` now completes the read step (previously blocked by the 500 error).

## Test plan

- [ ] `npm test` passes
- [ ] Seed a message via `POST /__fws/setup/gmail/message` and verify `gws gmail +read --id <id>` returns without the Message-ID error