### PR TITLE
ci: matrix test gws 0.16.0, 0.22.5, and latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,12 @@ on:
 
 jobs:
   unit:
-    name: unit tests
+    name: unit tests (gws ${{ matrix.gws-version }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        gws-version: ['0.16.0', '0.22.5', 'latest']
     steps:
       - uses: actions/checkout@v4
 
@@ -22,8 +26,11 @@ jobs:
 
       # Required by tests in test/gws-validation.test.ts and test/calendar.test.ts
       # which spawn the real `gws` binary against the in-process mock server.
-      - name: Install gws CLI (latest)
-        run: npm install -g @googleworkspace/cli
+      - name: Install gws CLI (${{ matrix.gws-version }})
+        run: npm install -g @googleworkspace/cli@${{ matrix.gws-version }}
+
+      - name: Verify gws version
+        run: gws --version
 
       # `gh` is preinstalled on ubuntu-latest runners, but pin to latest to be safe.
       - name: Verify gh CLI
@@ -36,8 +43,12 @@ jobs:
         run: npm run test:unit
 
   e2e:
-    name: e2e tests (real daemon)
+    name: e2e tests (real daemon, gws ${{ matrix.gws-version }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        gws-version: ['0.16.0', '0.22.5', 'latest']
     steps:
       - uses: actions/checkout@v4
 
@@ -49,8 +60,11 @@ jobs:
       - name: Install fws deps
         run: npm ci
 
-      - name: Install gws CLI (latest)
-        run: npm install -g @googleworkspace/cli
+      - name: Install gws CLI (${{ matrix.gws-version }})
+        run: npm install -g @googleworkspace/cli@${{ matrix.gws-version }}
+
+      - name: Verify gws version
+        run: gws --version
 
       - name: Verify gh CLI
         run: gh --version


### PR DESCRIPTION
## Summary

- CI previously installed `@googleworkspace/cli` without a version pin, so both jobs silently drifted to whatever npm's `latest` happened to be. Regressions against older gws releases (e.g. the 0.16.0 path that `a82f95d` validated locally) were invisible, and the recently-fixed missing-`Message-ID` bug (#21) only surfaced once `latest` rolled past 0.22.0.
- Run both `unit` and `e2e` across three gws versions with `fail-fast: false` so every version's failure surface is visible in one CI run.
- Add a `gws --version` step for easy triage.

## Versions chosen

| Version | Why |
| --- | --- |
| `0.16.0` | Oldest release the project has actively validated against. |
| `0.22.5` | First release enforcing the stricter `Message-ID` requirement (context from #21 / commit `a82f95d`). |
| `latest` | Keeps catching upstream regressions as gws evolves. |

## Test plan

- [ ] All 6 matrix legs (2 jobs × 3 versions) run and the `gws --version` step reports the intended version.
- [ ] Unit and e2e tests are green on all three versions. If 0.16.0 fails, PR #21's fix should still hold — investigate if not.
- [ ] No job is cancelled early due to another leg failing (verifies `fail-fast: false`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)