### PR TITLE
fix(github): return full comments connection shape for gh issue view

### DIFF
--- a/src/server/routes/github.ts
+++ b/src/server/routes/github.ts
@@ -1,6 +1,34 @@
 import { Router } from 'express';
 import { getStore } from '../../store/index.js';
+import type { GitHubComment } from '../../store/types.js';
 import { generateId } from '../../util/id.js';
+
+// Shared shape builders keep the issue-view and pr-view GraphQL paths in lockstep.
+// gh's Go client nil-derefs on missing fields (see issue #26), so every path that
+// returns a comments connection must go through these helpers.
+function buildCommentNode(c: GitHubComment) {
+  return {
+    id: `C_${c.id}`,
+    author: { login: c.user.login, id: `U_${c.user.id}`, name: c.user.login },
+    authorAssociation: 'NONE',
+    body: c.body,
+    createdAt: c.created_at,
+    includesCreatedEdit: false,
+    isMinimized: false,
+    minimizedReason: '',
+    reactionGroups: [],
+    url: c.html_url,
+    viewerDidAuthor: false,
+  };
+}
+
+function buildCommentsConnection(comments: GitHubComment[]) {
+  return {
+    nodes: comments.map(buildCommentNode),
+    pageInfo: { hasNextPage: false, endCursor: null },
+    totalCount: comments.length,
+  };
+}
 
 export function githubRoutes(): Router {
   const r = Router();
@@ -62,23 +90,7 @@ export function githubRoutes(): Router {
               assignees: { nodes: [], totalCount: 0 },
               labels: { nodes: [], totalCount: 0 },
               milestone: null,
-              comments: {
-                nodes: comments.map(c => ({
-                  id: `C_${c.id}`,
-                  author: { login: c.user.login, id: `U_${c.user.id}`, name: c.user.login },
-                  authorAssociation: 'NONE',
-                  body: c.body,
-                  createdAt: c.created_at,
-                  includesCreatedEdit: false,
-                  isMinimized: false,
-                  minimizedReason: '',
-                  reactionGroups: [],
-                  url: c.html_url,
-                  viewerDidAuthor: false,
-                })),
-                pageInfo: { hasNextPage: false, endCursor: null },
-                totalCount: comments.length,
-              },
+              comments: buildCommentsConnection(comments),
               reactionGroups: [],
               commits: { totalCount: 1 },
               statusCheckRollup: { nodes: [{ commit: { statusCheckRollup: { contexts: { nodes: [], pageInfo: { hasNextPage: false, endCursor: null } } } } }] },
@@ -129,19 +141,7 @@ export function githubRoutes(): Router {
                   totalCount: isIssue ? (issue!.labels || []).length : 0,
                 },
                 reactionGroups: [],
-                comments: {
-                  nodes: comments.slice(-1).map(c => ({
-                    author: { login: c.user.login, id: `U_${c.user.id}`, name: c.user.login },
-                    authorAssociation: 'NONE',
-                    body: c.body,
-                    createdAt: c.created_at,
-                    includesCreatedEdit: false,
-                    isMinimized: false,
-                    minimizedReason: '',
-                    reactionGroups: [],
-                  })),
-                  totalCount: comments.length,
-                },
+                comments: buildCommentsConnection(comments),
                 // PR-specific fields
                 ...(pull ? {
                   headRefName: pull.head.ref,

--- a/test/gh-validation.test.ts
+++ b/test/gh-validation.test.ts
@@ -114,6 +114,12 @@ describe('gh CLI validation', () => {
       expect(stdout).toContain('OPEN');
     });
 
+    it('gh issue view 1 --comments', async () => {
+      const { stdout, stderr, exitCode } = await h.ghProxyWithRepo('issue view 1 --comments');
+      expect(exitCode, `gh stderr: ${stderr}\ngh stdout: ${stdout}`).toBe(0);
+      expect(stdout).toContain('bob');
+    });
+
     it('gh pr list', async () => {
       const { stdout, exitCode } = await h.ghProxyWithRepo('pr list');
       expect(exitCode).toBe(0);


### PR DESCRIPTION
## Summary
- `gh issue view <N> --comments` was crashing with SIGSEGV inside gh's `preloadIssueComments` because the `issueOrPullRequest` GraphQL path in the mock returned a comments connection missing `pageInfo` and several per-node fields (`id`, `url`, `viewerDidAuthor`). The `pullRequest` path already had the correct shape.
- Extracted `buildCommentNode` / `buildCommentsConnection` helpers so the issue-view and pr-view paths share a single source of truth and can't drift again — which was the structural root cause.
- Also dropped an errant `comments.slice(-1)` that was returning only the last comment from issue view.

Fixes #26

## Test plan
- [x] `npx vitest run test/gh-validation.test.ts` — 16/16 pass
- [x] New regression: `gh issue view 1 --comments` exits 0 and shows the comment author
- [x] `npx tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)