### PR TITLE
fix(mitm): strip Transfer-Encoding on buffered responses so git clone works

### DIFF
--- a/src/proxy/mitm.ts
+++ b/src/proxy/mitm.ts
@@ -410,16 +410,25 @@ function handleInterceptedRequest(tlsSocket: tls.TLSSocket, hostname: string, mo
           const body = Buffer.concat(chunks);
           let respHeader = `HTTP/1.1 ${mockRes.statusCode ?? 502} ${mockRes.statusMessage ?? ''}\r\n`;
           let upstreamWantsClose = false;
+          // Buffering the mock response means we're writing it as a single
+          // framed block, so we must advertise Content-Length and drop any
+          // upstream Transfer-Encoding — otherwise clients that trust the
+          // chunked header (e.g. git smart HTTP, which streams packfiles)
+          // will try to parse the raw body as chunked and fail with
+          // "Malformed encoding found in chunked-encoding".
           for (const [key, val] of Object.entries(mockRes.headers)) {
             if (val == null) continue;
+            const lower = key.toLowerCase();
+            if (lower === 'transfer-encoding' || lower === 'content-length') continue;
             const vals = Array.isArray(val) ? val : [val];
             for (const v of vals) {
               respHeader += `${key}: ${v}\r\n`;
-              if (key.toLowerCase() === 'connection' && String(v).toLowerCase() === 'close') {
+              if (lower === 'connection' && String(v).toLowerCase() === 'close') {
                 upstreamWantsClose = true;
               }
             }
           }
+          respHeader += `Content-Length: ${body.length}\r\n`;
           respHeader += '\r\n';
 
           try {

--- a/test/git-http.test.ts
+++ b/test/git-http.test.ts
@@ -96,6 +96,51 @@ describe('git smart HTTP', () => {
     expect(src).toBe('console.log("hi");\n');
   }, 45_000);
 
+  it('clones through the MITM proxy against https://github.com/<owner>/<repo>.git', async () => {
+    // Regression: the MITM proxy buffers the mock response and re-emits it as
+    // a single block. If it passes through the upstream `Transfer-Encoding:
+    // chunked` header while writing the body un-chunked, git aborts with
+    // "Malformed encoding found in chunked-encoding" mid-clone.
+    await h.fetch('/__fws/setup/github/repo', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        owner: 'octo',
+        repo: 'via-proxy',
+        files: [{ path: 'README.md', content: 'via proxy\n' }],
+      }),
+    });
+
+    const dest = path.join(await mkWorkdir(), 'via-proxy');
+    const { stdout, stderr, code } = await new Promise<{ stdout: string; stderr: string; code: number }>((resolve) => {
+      execFile(
+        'git',
+        ['clone', '--no-hardlinks', 'https://github.com/octo/via-proxy.git', dest],
+        {
+          env: {
+            ...process.env,
+            HTTPS_PROXY: `http://localhost:${h.proxyPort}`,
+            SSL_CERT_FILE: h.caBundlePath,
+            GIT_SSL_CAINFO: h.caBundlePath,
+            GIT_TERMINAL_PROMPT: '0',
+          },
+          timeout: 30_000,
+        },
+        (err, out, errOut) => {
+          resolve({
+            stdout: out ?? '',
+            stderr: errOut ?? '',
+            code: err ? ((err as { code?: number }).code ?? 1) : 0,
+          });
+        },
+      );
+    });
+
+    expect(code, `stdout=${stdout}\nstderr=${stderr}`).toBe(0);
+    const readme = await readFile(path.join(dest, 'README.md'), 'utf-8');
+    expect(readme).toBe('via proxy\n');
+  }, 45_000);
+
   it('refuses push via git-receive-pack', async () => {
     await h.fetch('/__fws/setup/github/repo', {
       method: 'POST',

--- a/test/helpers/harness.ts
+++ b/test/helpers/harness.ts
@@ -10,6 +10,10 @@ import type { Server } from 'node:http';
 
 export interface TestHarness {
   port: number;
+  /** MITM proxy port (HTTPS_PROXY target). */
+  proxyPort: number;
+  /** Absolute path to the MITM CA bundle for SSL_CERT_FILE / GIT_SSL_CAINFO. */
+  caBundlePath: string;
   /** Direct HTTP fetch against mock server */
   fetch: (urlPath: string, init?: RequestInit) => Promise<Response>;
   /** Run gws command (uses discovery cache rewriting for regular commands) */
@@ -111,6 +115,8 @@ export async function createTestHarness(): Promise<TestHarness> {
 
   return {
     port,
+    proxyPort,
+    caBundlePath: bundlePath,
     fetch: (urlPath: string, init?: RequestInit) =>
       globalThis.fetch(`http://localhost:${port}${urlPath}`, init),
     gws: (args: string) => runCmd(gwsPath, args, baseEnv),


### PR DESCRIPTION
Follow-up to #28.

## Problem

Cloning via the MITM proxy (`HTTPS_PROXY=http://…:4101 git clone https://github.com/<owner>/<repo>.git`) failed immediately with:

```
fatal: Malformed encoding found in chunked-encoding
```

even though direct HTTP against the mock server (`git clone http://localhost:4100/…`) worked fine.

## Cause

`src/proxy/mitm.ts::handleConnectTunnel` buffers the mock-server response and re-emits it to the TLS-facing socket as a **single framed block** — but it forwards the upstream response headers verbatim. When the mock response comes back with `Transfer-Encoding: chunked` (Express sets this automatically on piped streams, and the new `git upload-pack` route pipes), the client trusts the header and tries to parse the un-chunked body as chunked → the error above.

REST/GraphQL routes never hit this because Express ends up emitting `Content-Length` for those hand-rolled JSON responses. The git smart HTTP routes are the first ones that actually stream, so they were the first to surface the bug.

## Fix

When we buffer, we now advertise `Content-Length: <body.length>` and drop any upstream `Transfer-Encoding` / stale `Content-Length`, so the framing matches what we actually wrote. Buffering semantics are unchanged — still a single-block response — we're just telling the client what frame we chose.

## Test

New case in `test/git-http.test.ts` clones a seeded repo through the MITM proxy (`HTTPS_PROXY=…` + `SSL_CERT_FILE`) instead of direct HTTP. Pre-fix this failed with the encoding error; now passes. Also exposed `proxyPort` / `caBundlePath` on the test harness so future tests can exercise the full TLS chain.

Full unit suite (189 tests) green.

## Note

Buffering the whole response in memory isn't ideal for large packfiles; streaming would be the right long-term fix. That's a separate concern from this regression — the frame mismatch would break chunked responses of any size.

🤖 Generated with [Claude Code](https://claude.com/claude-code)