### PR TITLE
feat(seed): make GitHub user identity runtime-configurable for plausible authors

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,31 @@ fws reset --snapshot my-scenario  # Reset to a specific snapshot
 
 Snapshots are stored in `~/.local/share/fws/snapshots/` (override with `FWS_DATA_DIR`).
 
+### Customizing the seeded identity
+
+The default seeded user (`testuser` / "Test User" / `testuser/my-project`) is a
+giveaway when you point an LLM agent at fws and want it to behave as if it's
+working against a normal corporate repo. Override at server start with env vars:
+
+```bash
+FWS_USER_LOGIN=alex.park \
+FWS_USER_NAME="Alex Park" \
+FWS_USER_EMAIL=alex.park@platform.internal \
+FWS_GITHUB_REPO=platform/weather-outfit-recommender \
+fws server start
+```
+
+`FWS_GITHUB_REPO` accepts either a bare repo name (owner falls back to
+`FWS_USER_LOGIN`) or `owner/repo` for non-personal owners. The override
+flows through GitHub user/repo/issues/PRs/comments and the Gmail / Calendar
+/ Drive owner email + display name. `fws server env` echoes back the
+resolved `GH_REPO` so `eval $(fws server env)` always exports the right
+default.
+
+Snapshots already capture the resolved identity through the regular store
+serialization, so a custom owner + repo set is persistable across restarts
+via `fws snapshot save` / `fws snapshot load`.
+
 ## Default seed data
 
 | Service  | Data |
@@ -130,7 +155,7 @@ Snapshots are stored in `~/.local/share/fws/snapshots/` (override with `FWS_DATA
 | Tasks    | 1 task list with 2 tasks (1 pending, 1 completed) |
 | Sheets   | 1 spreadsheet ("Budget 2026") |
 | People   | 2 contacts (Alice, Bob), 1 contact group |
-| GitHub   | 1 repo (testuser/my-project), 2 issues, 1 PR, 1 comment |
+| GitHub   | 1 repo (testuser/my-project — see "Customizing the seeded identity" to override), 2 issues, 1 PR, 1 comment |
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -48,10 +48,11 @@ gws gmail +triage
 gws calendar events list --params '{"calendarId":"primary"}'
 gws drive files list
 
-# Try gh commands
-gh issue list                                      # requires GH_REPO=testuser/my-project
-gh api /repos/testuser/my-project/issues
+# Try gh commands (gh reads owner/repo from the current checkout's
+# .git/config — run inside a checkout, or prefix with GH_REPO=owner/repo)
 gh api /user
+GH_REPO=testuser/my-project gh issue list
+gh api /repos/testuser/my-project/issues
 
 # When done
 fws server stop
@@ -120,30 +121,58 @@ fws reset --snapshot my-scenario  # Reset to a specific snapshot
 
 Snapshots are stored in `~/.local/share/fws/snapshots/` (override with `FWS_DATA_DIR`).
 
-### Customizing the seeded identity
+### Posting issues / PRs as different users
 
-The default seeded user (`testuser` / "Test User" / `testuser/my-project`) is a
-giveaway when you point an LLM agent at fws and want it to behave as if it's
-working against a normal corporate repo. Override at server start with env vars:
+The default seeded "self" user is `testuser` / "Test User" /
+`testuser@example.com`. When fws creates a new issue, PR, or comment via
+the gh API it stamps `user.login` with whoever the seeded self user is at
+that moment — agents read this back from the API and weight a request
+from `testuser` differently from one from `alex.park`, so for agent-eval
+runs you'll typically want a plausible login.
+
+Set the **initial** identity at server start (optional):
 
 ```bash
 FWS_USER_LOGIN=alex.park \
 FWS_USER_NAME="Alex Park" \
 FWS_USER_EMAIL=alex.park@platform.internal \
-FWS_GITHUB_REPO=platform/weather-outfit-recommender \
 fws server start
 ```
 
-`FWS_GITHUB_REPO` accepts either a bare repo name (owner falls back to
-`FWS_USER_LOGIN`) or `owner/repo` for non-personal owners. The override
-flows through GitHub user/repo/issues/PRs/comments and the Gmail / Calendar
-/ Drive owner email + display name. `fws server env` echoes back the
-resolved `GH_REPO` so `eval $(fws server env)` always exports the right
-default.
+…and switch it **at runtime** to alternate authors in one session:
 
-Snapshots already capture the resolved identity through the regular store
-serialization, so a custom owner + repo set is persistable across restarts
-via `fws snapshot save` / `fws snapshot load`.
+```bash
+fws github user set --login alex.park --name "Alex Park"
+gh issue create -t "..." -b "..."   # → user.login = alex.park
+
+fws github user set --login david.kim --name "David Kim"
+gh issue create -t "..." -b "..."   # → user.login = david.kim
+```
+
+The display name also flows to Drive owner / Gmail sendAs without a
+restart. Snapshots capture the live identity, so it persists across
+`fws snapshot save` / `fws snapshot load`.
+
+### Working against a different repo
+
+The seeded repo is always `${login}/my-project`. The store is keyed by
+repo full_name, so additional repos are first-class — create one and
+work in it:
+
+```bash
+gh repo create platform/weather-outfit-recommender   # API-only repo entry
+# …or, to also materialize a clonable bare repo on disk so `git clone` works:
+curl -sX POST http://localhost:4100/__fws/setup/github/repo \
+  -H 'content-type: application/json' \
+  -d '{"owner":"platform","repo":"weather-outfit-recommender","files":[{"path":"README.md","content":"# weather-outfit-recommender\n"}]}'
+git clone http://localhost:4100/git/platform/weather-outfit-recommender.git
+cd weather-outfit-recommender
+gh issue create -t "Fix login bug" -b "..."   # gh reads owner/repo from .git/config
+```
+
+`fws server env` does not export `GH_REPO` — gh reads owner/repo from
+the current checkout's `.git/config`. If you run gh outside a checkout,
+prefix the call with `GH_REPO=owner/repo`.
 
 ## Default seed data
 
@@ -155,7 +184,7 @@ via `fws snapshot save` / `fws snapshot load`.
 | Tasks    | 1 task list with 2 tasks (1 pending, 1 completed) |
 | Sheets   | 1 spreadsheet ("Budget 2026") |
 | People   | 2 contacts (Alice, Bob), 1 contact group |
-| GitHub   | 1 repo (testuser/my-project — see "Customizing the seeded identity" to override), 2 issues, 1 PR, 1 comment |
+| GitHub   | 1 repo (`${login}/my-project`, default `testuser/my-project`), 2 issues, 1 PR, 1 comment — see "Posting issues / PRs as different users" and "Working against a different repo" |
 
 ## Documentation
 

--- a/bin/fws.ts
+++ b/bin/fws.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env tsx
 import { Command } from 'commander';
 import { createApp } from '../src/server/app.js';
-import { loadStore, deserializeStore, getStore } from '../src/store/index.js';
+import { loadStore, deserializeStore } from '../src/store/index.js';
 import { generateConfigDir } from '../src/config/rewrite-cache.js';
 import { generateCACert, startMitmProxy } from '../src/proxy/mitm.js';
 import { spawn } from 'node:child_process';
@@ -78,19 +78,9 @@ serverCmd
       const proxyPort = port + 1;
       const proxyServer = startMitmProxy(port, proxyPort);
 
-      // Capture the resolved seed identity (after any snapshot load) so
-      // `fws server env` and the start banner can echo back the right
-      // GH_REPO without the parent shell needing to set FWS_USER_LOGIN
-      // again. Snapshots may carry a different identity than the env vars.
-      const liveStore = getStore();
-      const ghLogin = liveStore.github.user.login;
-      const firstRepo = Object.values(liveStore.github.repos)[0];
-      const ghRepo = firstRepo?.full_name || `${ghLogin}/my-project`;
-
       await ensureDir(getDataDir());
       await fs.writeFile(getServerInfoPath(), JSON.stringify({
         port, proxyPort, pid: process.pid, caPath, bundlePath,
-        ghLogin, ghRepo,
       }));
 
       const shutdown = () => {
@@ -155,7 +145,6 @@ serverCmd
       const serverInfo = JSON.parse(await fs.readFile(getServerInfoPath(), 'utf-8').catch(() => '{}'));
       const proxyPort = serverInfo.proxyPort || port + 1;
       const bundlePath = serverInfo.bundlePath || path.join(getDataDir(), 'certs', 'ca-bundle.crt');
-      const ghRepo = serverInfo.ghRepo || 'testuser/my-project';
 
       console.log(`fws server started on port ${port} (pid ${child.pid})\n`);
       console.log(`Run this to configure your shell:\n`);
@@ -165,8 +154,9 @@ serverCmd
       console.log(`  export GOOGLE_WORKSPACE_CLI_TOKEN=fake`);
       console.log(`  export HTTPS_PROXY=http://localhost:${proxyPort}`);
       console.log(`  export SSL_CERT_FILE=${bundlePath}`);
-      console.log(`  export GH_TOKEN=fake`);
-      console.log(`  export GH_REPO=${ghRepo}\n`);
+      console.log(`  export GH_TOKEN=fake\n`);
+      console.log(`gh reads owner/repo from the current checkout's .git/config —`);
+      console.log(`run gh inside a checkout, or set GH_REPO=owner/repo manually.\n`);
       console.log(`Then try:\n`);
       console.log(`  gws gmail +triage`);
       console.log(`  gws drive files list`);
@@ -206,13 +196,11 @@ serverCmd
       const bundlePath = info.bundlePath || path.join(getDataDir(), 'certs', 'ca-bundle.crt');
       const proxyPort = info.proxyPort || info.port + 1;
 
-      const ghRepo = info.ghRepo || 'testuser/my-project';
       console.log(`export GOOGLE_WORKSPACE_CLI_CONFIG_DIR=${configDir}`);
       console.log(`export GOOGLE_WORKSPACE_CLI_TOKEN=fake`);
       console.log(`export HTTPS_PROXY=http://localhost:${proxyPort}`);
       console.log(`export SSL_CERT_FILE=${bundlePath}`);
       console.log(`export GH_TOKEN=fake`);
-      console.log(`export GH_REPO=${ghRepo}`);
     } catch {
       console.error('No running server found. Start with: fws server start');
       process.exit(1);
@@ -396,6 +384,36 @@ program
         });
         console.log(`File added: ${data.id}`);
       }),
+  );
+
+// fws github user set
+program
+  .command('github')
+  .description("Manage the running daemon's GitHub state")
+  .addCommand(
+    new Command('user')
+      .description('Manage the seeded "self" user')
+      .addCommand(
+        new Command('set')
+          .description('Update the GitHub login / display name / email used for new issues, PRs, and comments. Useful for posting as different authors in one session.')
+          .option('--login <login>', 'GitHub login (e.g. alex.park)')
+          .option('--name <name>', 'Display name (e.g. "Alex Park") — also flows to Drive owner / Gmail sendAs')
+          .option('--email <email>', 'GitHub email address')
+          .option('-p, --port <port>', 'Server port', String(DEFAULT_PORT))
+          .action(async (opts) => {
+            if (!opts.login && !opts.name && !opts.email) {
+              console.error('at least one of --login / --name / --email is required');
+              process.exit(1);
+            }
+            const port = parseInt(opts.port);
+            const data = await postSetup(port, '/__fws/setup/github/user', {
+              login: opts.login,
+              name: opts.name,
+              email: opts.email,
+            });
+            console.log(`user updated: login=${data.login} name=${data.name} email=${data.email}`);
+          }),
+      ),
   );
 
 // fws search add

--- a/bin/fws.ts
+++ b/bin/fws.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env tsx
 import { Command } from 'commander';
 import { createApp } from '../src/server/app.js';
-import { loadStore, deserializeStore } from '../src/store/index.js';
+import { loadStore, deserializeStore, getStore } from '../src/store/index.js';
 import { generateConfigDir } from '../src/config/rewrite-cache.js';
 import { generateCACert, startMitmProxy } from '../src/proxy/mitm.js';
 import { spawn } from 'node:child_process';
@@ -78,9 +78,19 @@ serverCmd
       const proxyPort = port + 1;
       const proxyServer = startMitmProxy(port, proxyPort);
 
+      // Capture the resolved seed identity (after any snapshot load) so
+      // `fws server env` and the start banner can echo back the right
+      // GH_REPO without the parent shell needing to set FWS_USER_LOGIN
+      // again. Snapshots may carry a different identity than the env vars.
+      const liveStore = getStore();
+      const ghLogin = liveStore.github.user.login;
+      const firstRepo = Object.values(liveStore.github.repos)[0];
+      const ghRepo = firstRepo?.full_name || `${ghLogin}/my-project`;
+
       await ensureDir(getDataDir());
       await fs.writeFile(getServerInfoPath(), JSON.stringify({
         port, proxyPort, pid: process.pid, caPath, bundlePath,
+        ghLogin, ghRepo,
       }));
 
       const shutdown = () => {
@@ -145,6 +155,7 @@ serverCmd
       const serverInfo = JSON.parse(await fs.readFile(getServerInfoPath(), 'utf-8').catch(() => '{}'));
       const proxyPort = serverInfo.proxyPort || port + 1;
       const bundlePath = serverInfo.bundlePath || path.join(getDataDir(), 'certs', 'ca-bundle.crt');
+      const ghRepo = serverInfo.ghRepo || 'testuser/my-project';
 
       console.log(`fws server started on port ${port} (pid ${child.pid})\n`);
       console.log(`Run this to configure your shell:\n`);
@@ -155,7 +166,7 @@ serverCmd
       console.log(`  export HTTPS_PROXY=http://localhost:${proxyPort}`);
       console.log(`  export SSL_CERT_FILE=${bundlePath}`);
       console.log(`  export GH_TOKEN=fake`);
-      console.log(`  export GH_REPO=testuser/my-project\n`);
+      console.log(`  export GH_REPO=${ghRepo}\n`);
       console.log(`Then try:\n`);
       console.log(`  gws gmail +triage`);
       console.log(`  gws drive files list`);
@@ -195,12 +206,13 @@ serverCmd
       const bundlePath = info.bundlePath || path.join(getDataDir(), 'certs', 'ca-bundle.crt');
       const proxyPort = info.proxyPort || info.port + 1;
 
+      const ghRepo = info.ghRepo || 'testuser/my-project';
       console.log(`export GOOGLE_WORKSPACE_CLI_CONFIG_DIR=${configDir}`);
       console.log(`export GOOGLE_WORKSPACE_CLI_TOKEN=fake`);
       console.log(`export HTTPS_PROXY=http://localhost:${proxyPort}`);
       console.log(`export SSL_CERT_FILE=${bundlePath}`);
       console.log(`export GH_TOKEN=fake`);
-      console.log(`export GH_REPO=testuser/my-project`);
+      console.log(`export GH_REPO=${ghRepo}`);
     } catch {
       console.error('No running server found. Start with: fws server start');
       process.exit(1);

--- a/src/server/routes/calendar.ts
+++ b/src/server/routes/calendar.ts
@@ -1,7 +1,6 @@
 import { Router } from 'express';
 import { getStore } from '../../store/index.js';
 import { generateId, generateEtag } from '../../util/id.js';
-import { DEFAULT_USER_EMAIL } from '../../store/seed.js';
 
 export function calendarRoutes(): Router {
   const r = Router();

--- a/src/server/routes/control.ts
+++ b/src/server/routes/control.ts
@@ -128,7 +128,7 @@ export function controlRoutes(): Router {
       size: size ? String(size) : undefined,
       trashed: false,
       starred: false,
-      owners: [{ emailAddress: userEmail, displayName: 'Test User' }],
+      owners: [{ emailAddress: userEmail, displayName: store.gmail.profile.displayName }],
       description,
     };
 

--- a/src/server/routes/control.ts
+++ b/src/server/routes/control.ts
@@ -142,6 +142,44 @@ export function controlRoutes(): Router {
     res.json({ status: 'reset', scope: 'webFetch' });
   });
 
+  // Mutate the seeded "self" user. Lets an operator alternate authors at
+  // runtime — `fws github user set --login alex.park`, then a `gh issue
+  // create` is stamped with alex.park as user.login; switch again to
+  // david.kim before the next create. Only fields included in the body
+  // are touched, so partial updates work.
+  r.post('/__fws/setup/github/user', (req, res) => {
+    const body = req.body ?? {};
+    if (body.login !== undefined && typeof body.login !== 'string') {
+      return res.status(400).json({ error: 'login must be a string' });
+    }
+    if (body.name !== undefined && typeof body.name !== 'string') {
+      return res.status(400).json({ error: 'name must be a string' });
+    }
+    if (body.email !== undefined && typeof body.email !== 'string') {
+      return res.status(400).json({ error: 'email must be a string' });
+    }
+    const store = getStore();
+    if (typeof body.login === 'string') {
+      store.github.user.login = body.login;
+      store.github.user.avatar_url = `https://github.com/${body.login}.png`;
+      store.github.user.html_url = `https://github.com/${body.login}`;
+    }
+    if (typeof body.name === 'string') {
+      store.github.user.name = body.name;
+      // Display name is shared with Drive owners / Gmail sendAs, which
+      // read store.gmail.profile.displayName at request time.
+      store.gmail.profile.displayName = body.name;
+    }
+    if (typeof body.email === 'string') {
+      store.github.user.email = body.email;
+    }
+    res.json({
+      login: store.github.user.login,
+      name: store.github.user.name,
+      email: store.github.user.email,
+    });
+  });
+
   // Create (or overwrite) a mock GitHub repo that clients can `git clone`.
   //   POST /__fws/setup/github/repo  { owner, repo, files?, defaultBranch?, ... }
   // Bare repo is materialized on disk so fws can delegate the clone protocol

--- a/src/server/routes/drive.ts
+++ b/src/server/routes/drive.ts
@@ -13,7 +13,7 @@ export function driveRoutes(): Router {
     res.json({
       kind: 'drive#about',
       user: {
-        displayName: 'Test User',
+        displayName: store.gmail.profile.displayName,
         emailAddress: userEmail,
         kind: 'drive#user',
         me: true,
@@ -89,7 +89,7 @@ export function driveRoutes(): Router {
       size: req.body.size,
       trashed: false,
       starred: req.body.starred || false,
-      owners: [{ emailAddress: userEmail, displayName: 'Test User' }],
+      owners: [{ emailAddress: userEmail, displayName: store.gmail.profile.displayName }],
       description: req.body.description,
     };
 
@@ -180,7 +180,7 @@ export function driveRoutes(): Router {
       });
     }
     // Return owner as default permission
-    const userEmail = getStore().gmail.profile.emailAddress;
+    const profile = getStore().gmail.profile;
     res.json({
       kind: 'drive#permissionList',
       permissions: [
@@ -188,9 +188,9 @@ export function driveRoutes(): Router {
           kind: 'drive#permission',
           id: 'owner',
           type: 'user',
-          emailAddress: userEmail,
+          emailAddress: profile.emailAddress,
           role: 'owner',
-          displayName: 'Test User',
+          displayName: profile.displayName,
         },
       ],
     });
@@ -204,15 +204,15 @@ export function driveRoutes(): Router {
         error: { code: 404, message: 'File not found.', status: 'NOT_FOUND' },
       });
     }
-    const userEmail = getStore().gmail.profile.emailAddress;
+    const profile = getStore().gmail.profile;
     if (req.params.permissionId === 'owner') {
       return res.json({
         kind: 'drive#permission',
         id: 'owner',
         type: 'user',
-        emailAddress: userEmail,
+        emailAddress: profile.emailAddress,
         role: 'owner',
-        displayName: 'Test User',
+        displayName: profile.displayName,
       });
     }
     res.status(404).json({

--- a/src/server/routes/gmail.ts
+++ b/src/server/routes/gmail.ts
@@ -351,7 +351,7 @@ export function gmailRoutes(): Router {
       sendAs: [
         {
           sendAsEmail: email,
-          displayName: 'Test User',
+          displayName: store.gmail.profile.displayName,
           isDefault: true,
           isPrimary: true,
           treatAsAlias: false,
@@ -372,7 +372,7 @@ export function gmailRoutes(): Router {
     }
     res.json({
       sendAsEmail: email,
-      displayName: 'Test User',
+      displayName: store.gmail.profile.displayName,
       isDefault: true,
       isPrimary: true,
       treatAsAlias: false,

--- a/src/store/seed.ts
+++ b/src/store/seed.ts
@@ -26,7 +26,37 @@ const SYSTEM_LABELS: GmailLabel[] = [
   { id: 'CATEGORY_FORUMS', name: 'CATEGORY_FORUMS', type: 'system' },
 ];
 
-const DEFAULT_EMAIL = 'testuser@example.com';
+// Default identity for the seeded mock user. Each can be overridden via
+// environment variables at server start so the agent under test sees a
+// plausible owner / author / email instead of `testuser` placeholders.
+//   FWS_USER_LOGIN     GitHub login (default: testuser)
+//   FWS_USER_NAME      Display name used everywhere a "Test User" label was
+//                      previously hardcoded (default: Test User)
+//   FWS_USER_EMAIL     Gmail / Calendar / Drive owner email + GitHub email
+//                      (default: testuser@example.com)
+//   FWS_GITHUB_REPO    Default seeded repo. Either a bare name (owner falls
+//                      back to FWS_USER_LOGIN) or owner/repo (default:
+//                      my-project)
+// Snapshots already capture the resolved values via the regular store
+// serialization, so a custom identity persists through fws snapshot save/load.
+export interface SeedIdentity {
+  login: string;
+  name: string;
+  email: string;
+  repoOwner: string;
+  repoName: string;
+}
+
+export function resolveSeedIdentity(env: NodeJS.ProcessEnv = process.env): SeedIdentity {
+  const login = env.FWS_USER_LOGIN || 'testuser';
+  const name = env.FWS_USER_NAME || 'Test User';
+  const email = env.FWS_USER_EMAIL || 'testuser@example.com';
+  const repoSpec = env.FWS_GITHUB_REPO || 'my-project';
+  const slash = repoSpec.indexOf('/');
+  const repoOwner = slash >= 0 ? repoSpec.slice(0, slash) : login;
+  const repoName = slash >= 0 ? repoSpec.slice(slash + 1) : repoSpec;
+  return { login, name, email, repoOwner, repoName };
+}
 
 function makeMessage(id: string, threadId: string, historyId: number, opts: {
   from: string; to: string; subject: string; body: string;
@@ -63,7 +93,7 @@ function makeMessage(id: string, threadId: string, historyId: number, opts: {
   };
 }
 
-function makeEvent(id: string, opts: {
+function makeEvent(id: string, email: string, opts: {
   summary: string; start: string; end: string;
   description?: string; location?: string;
 }): CalendarEvent {
@@ -78,15 +108,15 @@ function makeEvent(id: string, opts: {
     end: { dateTime: opts.end },
     created: '2026-04-01T00:00:00Z',
     updated: '2026-04-01T00:00:00Z',
-    creator: { email: DEFAULT_EMAIL },
-    organizer: { email: DEFAULT_EMAIL, self: true },
+    creator: { email },
+    organizer: { email, self: true },
     etag: generateEtag(),
     htmlLink: `https://calendar.google.com/event?eid=${id}`,
     iCalUID: `${id}@example.com`,
   };
 }
 
-function makeFile(id: string, opts: {
+function makeFile(id: string, email: string, displayName: string, opts: {
   name: string; mimeType: string; parents?: string[];
 }): DriveFile {
   return {
@@ -99,49 +129,51 @@ function makeFile(id: string, opts: {
     modifiedTime: '2026-04-01T00:00:00Z',
     trashed: false,
     starred: false,
-    owners: [{ emailAddress: DEFAULT_EMAIL, displayName: 'Test User' }],
+    owners: [{ emailAddress: email, displayName }],
   };
 }
 
-export function createSeedStore(): FwsStore {
+export function createSeedStore(identity: SeedIdentity = resolveSeedIdentity()): FwsStore {
+  const userEmail = identity.email;
+  const userDisplayName = identity.name;
   const labels: Record<string, GmailLabel> = {};
   for (const label of SYSTEM_LABELS) {
     labels[label.id] = { ...label };
   }
   labels['Label_projects'] = { id: 'Label_projects', name: 'Projects', type: 'user' };
 
-  const calendarId = DEFAULT_EMAIL;
+  const calendarId = userEmail;
   const etag = generateEtag();
 
   // --- Sample emails ---
   const messages: Record<string, GmailMessage> = {};
   const sampleMessages = [
     makeMessage(SAMPLE_GMAIL_MESSAGE_IDS[0], SAMPLE_GMAIL_THREAD_IDS[0], 1001, {
-      from: 'alice@company.com', to: DEFAULT_EMAIL,
+      from: 'alice@company.com', to: userEmail,
       subject: 'Q3 Planning Meeting',
       body: 'Hi, let\'s meet tomorrow at 2pm to discuss Q3 planning. I\'ve shared the agenda doc in Drive.',
       labels: ['INBOX', 'UNREAD', 'IMPORTANT'], date: '2026-04-07T09:00:00Z',
     }),
     makeMessage(SAMPLE_GMAIL_MESSAGE_IDS[1], SAMPLE_GMAIL_THREAD_IDS[1], 1002, {
-      from: 'bob@company.com', to: DEFAULT_EMAIL,
+      from: 'bob@company.com', to: userEmail,
       subject: 'Code Review: auth refactor PR #42',
       body: 'Please review the auth middleware refactor when you get a chance. The PR is ready.',
       labels: ['INBOX', 'UNREAD'], date: '2026-04-07T10:30:00Z',
     }),
     makeMessage(SAMPLE_GMAIL_MESSAGE_IDS[2], SAMPLE_GMAIL_THREAD_IDS[2], 1003, {
-      from: 'notifications@github.com', to: DEFAULT_EMAIL,
+      from: 'notifications@github.com', to: userEmail,
       subject: '[project/repo] CI pipeline failed on main',
       body: 'Build #1234 failed. See details: https://github.com/project/repo/actions/runs/1234',
       labels: ['INBOX', 'UNREAD', 'CATEGORY_UPDATES'], date: '2026-04-07T11:00:00Z',
     }),
     makeMessage(SAMPLE_GMAIL_MESSAGE_IDS[3], SAMPLE_GMAIL_THREAD_IDS[3], 1004, {
-      from: DEFAULT_EMAIL, to: 'alice@company.com',
+      from: userEmail, to: 'alice@company.com',
       subject: 'Re: Project proposal',
       body: 'Looks good to me. Let\'s proceed with option B as discussed.',
       labels: ['SENT'], date: '2026-04-06T16:00:00Z',
     }),
     makeMessage(SAMPLE_GMAIL_MESSAGE_IDS[4], SAMPLE_GMAIL_THREAD_IDS[4], 1005, {
-      from: 'hr@company.com', to: DEFAULT_EMAIL,
+      from: 'hr@company.com', to: userEmail,
       subject: 'Reminder: Submit timesheet by Friday',
       body: 'Please submit your timesheet for this week by end of day Friday.',
       labels: ['INBOX'], date: '2026-04-05T08:00:00Z',
@@ -154,21 +186,21 @@ export function createSeedStore(): FwsStore {
   // --- Sample events ---
   const events: Record<string, CalendarEvent> = {};
   const sampleEvents = [
-    makeEvent('evt001', {
+    makeEvent('evt001', userEmail, {
       summary: 'Daily Standup',
       start: '2026-04-08T09:00:00Z', end: '2026-04-08T09:15:00Z',
     }),
-    makeEvent('evt002', {
+    makeEvent('evt002', userEmail, {
       summary: 'Q3 Planning Meeting',
       start: '2026-04-08T14:00:00Z', end: '2026-04-08T15:00:00Z',
       location: 'Conference Room A',
       description: 'Discuss Q3 roadmap and resource allocation',
     }),
-    makeEvent('evt003', {
+    makeEvent('evt003', userEmail, {
       summary: '1:1 with Manager',
       start: '2026-04-09T10:00:00Z', end: '2026-04-09T10:30:00Z',
     }),
-    makeEvent('evt004', {
+    makeEvent('evt004', userEmail, {
       summary: 'Team Lunch',
       start: '2026-04-10T12:00:00Z', end: '2026-04-10T13:00:00Z',
       location: 'Cafeteria',
@@ -181,11 +213,11 @@ export function createSeedStore(): FwsStore {
   // --- Sample drive files ---
   const files: Record<string, DriveFile> = {};
   const sampleFiles = [
-    makeFile('file001', { name: 'Q3 Planning Agenda', mimeType: 'application/vnd.google-apps.document' }),
-    makeFile('file002', { name: 'Budget 2026.xlsx', mimeType: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' }),
-    makeFile('file003', { name: 'Architecture Diagram.png', mimeType: 'image/png' }),
-    makeFile('file004', { name: 'Meeting Notes', mimeType: 'application/vnd.google-apps.document', parents: ['folder001'] }),
-    makeFile('folder001', { name: 'Project Docs', mimeType: 'application/vnd.google-apps.folder' }),
+    makeFile('file001', userEmail, userDisplayName, { name: 'Q3 Planning Agenda', mimeType: 'application/vnd.google-apps.document' }),
+    makeFile('file002', userEmail, userDisplayName, { name: 'Budget 2026.xlsx', mimeType: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' }),
+    makeFile('file003', userEmail, userDisplayName, { name: 'Architecture Diagram.png', mimeType: 'image/png' }),
+    makeFile('file004', userEmail, userDisplayName, { name: 'Meeting Notes', mimeType: 'application/vnd.google-apps.document', parents: ['folder001'] }),
+    makeFile('folder001', userEmail, userDisplayName, { name: 'Project Docs', mimeType: 'application/vnd.google-apps.folder' }),
   ];
   for (const file of sampleFiles) {
     files[file.id] = file;
@@ -194,7 +226,8 @@ export function createSeedStore(): FwsStore {
   return {
     gmail: {
       profile: {
-        emailAddress: DEFAULT_EMAIL,
+        emailAddress: userEmail,
+        displayName: userDisplayName,
         messagesTotal: sampleMessages.length,
         threadsTotal: sampleMessages.length,
         historyId: '1005',
@@ -208,7 +241,7 @@ export function createSeedStore(): FwsStore {
         [calendarId]: {
           kind: 'calendar#calendar',
           id: calendarId,
-          summary: DEFAULT_EMAIL,
+          summary: userEmail,
           timeZone: 'UTC',
           etag,
         },
@@ -220,7 +253,7 @@ export function createSeedStore(): FwsStore {
         [calendarId]: {
           kind: 'calendar#calendarListEntry',
           id: calendarId,
-          summary: DEFAULT_EMAIL,
+          summary: userEmail,
           timeZone: 'UTC',
           accessRole: 'owner',
           defaultReminders: [],
@@ -321,103 +354,7 @@ export function createSeedStore(): FwsStore {
         },
       },
     },
-    github: {
-      user: {
-        login: 'testuser',
-        id: 1,
-        name: 'Test User',
-        email: 'testuser@example.com',
-        avatar_url: 'https://github.com/testuser.png',
-        html_url: 'https://github.com/testuser',
-        type: 'User',
-      },
-      repos: {
-        'testuser/my-project': {
-          id: 101,
-          name: 'my-project',
-          full_name: 'testuser/my-project',
-          owner: { login: 'testuser', id: 1, type: 'User' },
-          private: false,
-          html_url: 'https://github.com/testuser/my-project',
-          description: 'A sample project for testing',
-          fork: false,
-          created_at: '2026-01-01T00:00:00Z',
-          updated_at: '2026-04-07T00:00:00Z',
-          pushed_at: '2026-04-07T00:00:00Z',
-          default_branch: 'main',
-          open_issues_count: 2,
-          language: 'TypeScript',
-          topics: ['testing', 'mock'],
-        },
-      },
-      issues: {
-        'testuser/my-project': {
-          1: {
-            id: 1001,
-            number: 1,
-            title: 'Fix login bug',
-            body: 'Users are getting 401 errors when trying to log in with SSO.',
-            state: 'open',
-            labels: [{ id: 1, name: 'bug', color: 'd73a4a' }],
-            assignees: [{ login: 'testuser', id: 1 }],
-            user: { login: 'alice', id: 2 },
-            created_at: '2026-04-05T10:00:00Z',
-            updated_at: '2026-04-06T14:00:00Z',
-            closed_at: null,
-            html_url: 'https://github.com/testuser/my-project/issues/1',
-            comments: 1,
-          },
-          2: {
-            id: 1002,
-            number: 2,
-            title: 'Add dark mode support',
-            body: 'It would be great to have a dark mode option.',
-            state: 'open',
-            labels: [{ id: 2, name: 'enhancement', color: 'a2eeef' }],
-            assignees: [],
-            user: { login: 'bob', id: 3 },
-            created_at: '2026-04-06T09:00:00Z',
-            updated_at: '2026-04-06T09:00:00Z',
-            closed_at: null,
-            html_url: 'https://github.com/testuser/my-project/issues/2',
-            comments: 0,
-          },
-        },
-      },
-      pulls: {
-        'testuser/my-project': {
-          3: {
-            id: 2001,
-            number: 3,
-            title: 'Fix SSO login flow',
-            body: 'Fixes #1. Updated the auth middleware to handle SSO tokens correctly.',
-            state: 'open',
-            head: { ref: 'fix/sso-login', sha: 'abc1234', label: 'testuser:fix/sso-login' },
-            base: { ref: 'main', sha: 'def5678', label: 'testuser:main' },
-            user: { login: 'testuser', id: 1 },
-            created_at: '2026-04-07T08:00:00Z',
-            updated_at: '2026-04-07T08:00:00Z',
-            merged_at: null,
-            closed_at: null,
-            html_url: 'https://github.com/testuser/my-project/pull/3',
-            mergeable: true,
-            draft: false,
-          },
-        },
-      },
-      comments: {
-        'testuser/my-project/issues/1': [
-          {
-            id: 3001,
-            body: 'I can reproduce this. Happens with Google SSO specifically.',
-            user: { login: 'bob', id: 3 },
-            created_at: '2026-04-06T14:00:00Z',
-            updated_at: '2026-04-06T14:00:00Z',
-            html_url: 'https://github.com/testuser/my-project/issues/1#issuecomment-3001',
-          },
-        ],
-      },
-    },
+    github: createGitHubSeed(identity),
     search: createSearchSeed(),
     webFetch: createWebFetchSeed(),
   };
@@ -502,4 +439,104 @@ function createSearchSeed(): SearchStore {
   };
 }
 
-export const DEFAULT_USER_EMAIL = DEFAULT_EMAIL;
+function createGitHubSeed(identity: SeedIdentity): GitHubStore {
+  const { login, name, email, repoOwner, repoName } = identity;
+  const repoFullName = `${repoOwner}/${repoName}`;
+  return {
+    user: {
+      login,
+      id: 1,
+      name,
+      email,
+      avatar_url: `https://github.com/${login}.png`,
+      html_url: `https://github.com/${login}`,
+      type: 'User',
+    },
+    repos: {
+      [repoFullName]: {
+        id: 101,
+        name: repoName,
+        full_name: repoFullName,
+        owner: { login: repoOwner, id: 1, type: 'User' },
+        private: false,
+        html_url: `https://github.com/${repoFullName}`,
+        description: 'A sample project for testing',
+        fork: false,
+        created_at: '2026-01-01T00:00:00Z',
+        updated_at: '2026-04-07T00:00:00Z',
+        pushed_at: '2026-04-07T00:00:00Z',
+        default_branch: 'main',
+        open_issues_count: 2,
+        language: 'TypeScript',
+        topics: ['testing', 'mock'],
+      },
+    },
+    issues: {
+      [repoFullName]: {
+        1: {
+          id: 1001,
+          number: 1,
+          title: 'Fix login bug',
+          body: 'Users are getting 401 errors when trying to log in with SSO.',
+          state: 'open',
+          labels: [{ id: 1, name: 'bug', color: 'd73a4a' }],
+          assignees: [{ login, id: 1 }],
+          user: { login: 'alice', id: 2 },
+          created_at: '2026-04-05T10:00:00Z',
+          updated_at: '2026-04-06T14:00:00Z',
+          closed_at: null,
+          html_url: `https://github.com/${repoFullName}/issues/1`,
+          comments: 1,
+        },
+        2: {
+          id: 1002,
+          number: 2,
+          title: 'Add dark mode support',
+          body: 'It would be great to have a dark mode option.',
+          state: 'open',
+          labels: [{ id: 2, name: 'enhancement', color: 'a2eeef' }],
+          assignees: [],
+          user: { login: 'bob', id: 3 },
+          created_at: '2026-04-06T09:00:00Z',
+          updated_at: '2026-04-06T09:00:00Z',
+          closed_at: null,
+          html_url: `https://github.com/${repoFullName}/issues/2`,
+          comments: 0,
+        },
+      },
+    },
+    pulls: {
+      [repoFullName]: {
+        3: {
+          id: 2001,
+          number: 3,
+          title: 'Fix SSO login flow',
+          body: 'Fixes #1. Updated the auth middleware to handle SSO tokens correctly.',
+          state: 'open',
+          head: { ref: 'fix/sso-login', sha: 'abc1234', label: `${login}:fix/sso-login` },
+          base: { ref: 'main', sha: 'def5678', label: `${login}:main` },
+          user: { login, id: 1 },
+          created_at: '2026-04-07T08:00:00Z',
+          updated_at: '2026-04-07T08:00:00Z',
+          merged_at: null,
+          closed_at: null,
+          html_url: `https://github.com/${repoFullName}/pull/3`,
+          mergeable: true,
+          draft: false,
+        },
+      },
+    },
+    comments: {
+      [`${repoFullName}/issues/1`]: [
+        {
+          id: 3001,
+          body: 'I can reproduce this. Happens with Google SSO specifically.',
+          user: { login: 'bob', id: 3 },
+          created_at: '2026-04-06T14:00:00Z',
+          updated_at: '2026-04-06T14:00:00Z',
+          html_url: `https://github.com/${repoFullName}/issues/1#issuecomment-3001`,
+        },
+      ],
+    },
+  };
+}

--- a/src/store/seed.ts
+++ b/src/store/seed.ts
@@ -26,36 +26,34 @@ const SYSTEM_LABELS: GmailLabel[] = [
   { id: 'CATEGORY_FORUMS', name: 'CATEGORY_FORUMS', type: 'system' },
 ];
 
-// Default identity for the seeded mock user. Each can be overridden via
-// environment variables at server start so the agent under test sees a
-// plausible owner / author / email instead of `testuser` placeholders.
+// Initial identity for the seeded mock user. Each can be set via env vars
+// at server start so the agent under test sees a plausible author / email
+// instead of `testuser` placeholders:
 //   FWS_USER_LOGIN     GitHub login (default: testuser)
 //   FWS_USER_NAME      Display name used everywhere a "Test User" label was
 //                      previously hardcoded (default: Test User)
 //   FWS_USER_EMAIL     Gmail / Calendar / Drive owner email + GitHub email
 //                      (default: testuser@example.com)
-//   FWS_GITHUB_REPO    Default seeded repo. Either a bare name (owner falls
-//                      back to FWS_USER_LOGIN) or owner/repo (default:
-//                      my-project)
-// Snapshots already capture the resolved values via the regular store
-// serialization, so a custom identity persists through fws snapshot save/load.
+// These are *initial* values only — the running server's user identity can
+// be changed at any time via `fws github user set` (or its underlying
+// /__fws/setup/github/user endpoint). Snapshots capture the live identity.
+//
+// The seeded repo is always `${login}/my-project`. To work against a
+// differently-named repo, create one at runtime (`gh repo create
+// owner/repo`, `git clone http://localhost/git/owner/repo.git`, etc.) — the
+// store is keyed by repo full_name, so multi-repo just works.
 export interface SeedIdentity {
   login: string;
   name: string;
   email: string;
-  repoOwner: string;
-  repoName: string;
 }
 
 export function resolveSeedIdentity(env: NodeJS.ProcessEnv = process.env): SeedIdentity {
-  const login = env.FWS_USER_LOGIN || 'testuser';
-  const name = env.FWS_USER_NAME || 'Test User';
-  const email = env.FWS_USER_EMAIL || 'testuser@example.com';
-  const repoSpec = env.FWS_GITHUB_REPO || 'my-project';
-  const slash = repoSpec.indexOf('/');
-  const repoOwner = slash >= 0 ? repoSpec.slice(0, slash) : login;
-  const repoName = slash >= 0 ? repoSpec.slice(slash + 1) : repoSpec;
-  return { login, name, email, repoOwner, repoName };
+  return {
+    login: env.FWS_USER_LOGIN || 'testuser',
+    name: env.FWS_USER_NAME || 'Test User',
+    email: env.FWS_USER_EMAIL || 'testuser@example.com',
+  };
 }
 
 function makeMessage(id: string, threadId: string, historyId: number, opts: {
@@ -440,8 +438,11 @@ function createSearchSeed(): SearchStore {
 }
 
 function createGitHubSeed(identity: SeedIdentity): GitHubStore {
-  const { login, name, email, repoOwner, repoName } = identity;
-  const repoFullName = `${repoOwner}/${repoName}`;
+  const { login, name, email } = identity;
+  // Seeded repo always lives under the seeded user. To use a different
+  // repo, create one at runtime (gh repo create / git clone / fws CLI) —
+  // the store is keyed by full_name so multi-repo is automatic.
+  const repoFullName = `${login}/my-project`;
   return {
     user: {
       login,
@@ -455,9 +456,9 @@ function createGitHubSeed(identity: SeedIdentity): GitHubStore {
     repos: {
       [repoFullName]: {
         id: 101,
-        name: repoName,
+        name: 'my-project',
         full_name: repoFullName,
-        owner: { login: repoOwner, id: 1, type: 'User' },
+        owner: { login, id: 1, type: 'User' },
         private: false,
         html_url: `https://github.com/${repoFullName}`,
         description: 'A sample project for testing',

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -23,6 +23,10 @@ export interface GmailStore {
 
 export interface GmailProfile {
   emailAddress: string;
+  // Used as the displayName everywhere a "Test User"-style label was previously
+  // hardcoded (Drive owner, Gmail sendAs, etc.). Populated at seed time so
+  // FWS_USER_NAME can override it without source edits — see seed.ts.
+  displayName: string;
   messagesTotal: number;
   threadsTotal: number;
   historyId: string;

--- a/test/seed-identity.test.ts
+++ b/test/seed-identity.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest';
+import { createSeedStore, resolveSeedIdentity } from '../src/store/seed.js';
+
+describe('seed identity overrides', () => {
+  it('uses the testuser defaults when no env vars are set', () => {
+    const store = createSeedStore(resolveSeedIdentity({}));
+    expect(store.github.user.login).toBe('testuser');
+    expect(store.github.user.name).toBe('Test User');
+    expect(store.github.user.email).toBe('testuser@example.com');
+    expect(store.github.repos['testuser/my-project']).toBeDefined();
+    expect(store.gmail.profile.emailAddress).toBe('testuser@example.com');
+    expect(store.gmail.profile.displayName).toBe('Test User');
+  });
+
+  it('lets FWS_USER_LOGIN / NAME / EMAIL override the seeded user', () => {
+    const store = createSeedStore(resolveSeedIdentity({
+      FWS_USER_LOGIN: 'alex.park',
+      FWS_USER_NAME: 'Alex Park',
+      FWS_USER_EMAIL: 'alex.park@platform.internal',
+    }));
+    expect(store.github.user.login).toBe('alex.park');
+    expect(store.github.user.name).toBe('Alex Park');
+    expect(store.github.user.email).toBe('alex.park@platform.internal');
+    expect(store.github.user.html_url).toBe('https://github.com/alex.park');
+
+    // The seeded repo follows the login by default, and so do the issue /
+    // PR / comment references — that's the bit the agent reads.
+    expect(store.github.repos['alex.park/my-project']).toBeDefined();
+    expect(store.github.repos['testuser/my-project']).toBeUndefined();
+    expect(store.github.pulls['alex.park/my-project'][3].head.label)
+      .toBe('alex.park:fix/sso-login');
+    expect(store.github.issues['alex.park/my-project'][1].assignees[0].login)
+      .toBe('alex.park');
+
+    // Other services share the identity.
+    expect(store.gmail.profile.emailAddress).toBe('alex.park@platform.internal');
+    expect(store.gmail.profile.displayName).toBe('Alex Park');
+    const driveOwner = Object.values(store.drive.files)[0].owners?.[0];
+    expect(driveOwner?.emailAddress).toBe('alex.park@platform.internal');
+    expect(driveOwner?.displayName).toBe('Alex Park');
+  });
+
+  it('FWS_GITHUB_REPO accepts owner/repo for non-personal owners', () => {
+    const store = createSeedStore(resolveSeedIdentity({
+      FWS_USER_LOGIN: 'alex.park',
+      FWS_GITHUB_REPO: 'platform/weather-outfit-recommender',
+    }));
+    expect(store.github.user.login).toBe('alex.park');
+    const repo = store.github.repos['platform/weather-outfit-recommender'];
+    expect(repo).toBeDefined();
+    expect(repo.owner.login).toBe('platform');
+    expect(repo.html_url).toBe('https://github.com/platform/weather-outfit-recommender');
+    expect(store.github.issues['platform/weather-outfit-recommender'][1].html_url)
+      .toBe('https://github.com/platform/weather-outfit-recommender/issues/1');
+  });
+
+  it('FWS_GITHUB_REPO without a slash keeps the owner = login', () => {
+    const store = createSeedStore(resolveSeedIdentity({
+      FWS_USER_LOGIN: 'alex.park',
+      FWS_GITHUB_REPO: 'weather-outfit-recommender',
+    }));
+    expect(store.github.repos['alex.park/weather-outfit-recommender']).toBeDefined();
+  });
+});

--- a/test/seed-identity.test.ts
+++ b/test/seed-identity.test.ts
@@ -1,7 +1,8 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { createSeedStore, resolveSeedIdentity } from '../src/store/seed.js';
+import { createTestHarness, type TestHarness } from './helpers/harness.js';
 
-describe('seed identity overrides', () => {
+describe('seed identity (initial values from env)', () => {
   it('uses the testuser defaults when no env vars are set', () => {
     const store = createSeedStore(resolveSeedIdentity({}));
     expect(store.github.user.login).toBe('testuser');
@@ -12,7 +13,7 @@ describe('seed identity overrides', () => {
     expect(store.gmail.profile.displayName).toBe('Test User');
   });
 
-  it('lets FWS_USER_LOGIN / NAME / EMAIL override the seeded user', () => {
+  it('lets FWS_USER_LOGIN / NAME / EMAIL set the initial seeded user', () => {
     const store = createSeedStore(resolveSeedIdentity({
       FWS_USER_LOGIN: 'alex.park',
       FWS_USER_NAME: 'Alex Park',
@@ -23,14 +24,12 @@ describe('seed identity overrides', () => {
     expect(store.github.user.email).toBe('alex.park@platform.internal');
     expect(store.github.user.html_url).toBe('https://github.com/alex.park');
 
-    // The seeded repo follows the login by default, and so do the issue /
-    // PR / comment references — that's the bit the agent reads.
+    // Repo full_name follows the configured login. We don't take a separate
+    // repo override — to use a different repo, create one at runtime.
     expect(store.github.repos['alex.park/my-project']).toBeDefined();
     expect(store.github.repos['testuser/my-project']).toBeUndefined();
     expect(store.github.pulls['alex.park/my-project'][3].head.label)
       .toBe('alex.park:fix/sso-login');
-    expect(store.github.issues['alex.park/my-project'][1].assignees[0].login)
-      .toBe('alex.park');
 
     // Other services share the identity.
     expect(store.gmail.profile.emailAddress).toBe('alex.park@platform.internal');
@@ -39,26 +38,65 @@ describe('seed identity overrides', () => {
     expect(driveOwner?.emailAddress).toBe('alex.park@platform.internal');
     expect(driveOwner?.displayName).toBe('Alex Park');
   });
+});
 
-  it('FWS_GITHUB_REPO accepts owner/repo for non-personal owners', () => {
-    const store = createSeedStore(resolveSeedIdentity({
-      FWS_USER_LOGIN: 'alex.park',
-      FWS_GITHUB_REPO: 'platform/weather-outfit-recommender',
-    }));
-    expect(store.github.user.login).toBe('alex.park');
-    const repo = store.github.repos['platform/weather-outfit-recommender'];
-    expect(repo).toBeDefined();
-    expect(repo.owner.login).toBe('platform');
-    expect(repo.html_url).toBe('https://github.com/platform/weather-outfit-recommender');
-    expect(store.github.issues['platform/weather-outfit-recommender'][1].html_url)
-      .toBe('https://github.com/platform/weather-outfit-recommender/issues/1');
+describe('runtime user-set endpoint', () => {
+  let h: TestHarness;
+  beforeAll(async () => { h = await createTestHarness(); });
+  afterAll(async () => { await h.cleanup(); });
+
+  it('alternating user.login between create calls stamps each issue with the right author', async () => {
+    // Switch to alex.park and create issue A.
+    await h.fetch('/__fws/setup/github/user', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ login: 'alex.park', name: 'Alex Park' }),
+    });
+    const a = await (await h.fetch('/repos/testuser/my-project/issues', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title: 'Issue A', body: 'from alex' }),
+    })).json();
+    expect(a.user.login).toBe('alex.park');
+
+    // Switch to david.kim and create issue B.
+    await h.fetch('/__fws/setup/github/user', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ login: 'david.kim', name: 'David Kim' }),
+    });
+    const b = await (await h.fetch('/repos/testuser/my-project/issues', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title: 'Issue B', body: 'from david' }),
+    })).json();
+    expect(b.user.login).toBe('david.kim');
+
+    // GET /user reflects the latest set.
+    const me = await (await h.fetch('/user')).json();
+    expect(me.login).toBe('david.kim');
+    expect(me.name).toBe('David Kim');
+
+    // Display name flows to Gmail sendAs / Drive owner without restart.
+    const sendAs = await (await h.fetch('/gmail/v1/users/me/settings/sendAs')).json();
+    expect(sendAs.sendAs[0].displayName).toBe('David Kim');
   });
 
-  it('FWS_GITHUB_REPO without a slash keeps the owner = login', () => {
-    const store = createSeedStore(resolveSeedIdentity({
-      FWS_USER_LOGIN: 'alex.park',
-      FWS_GITHUB_REPO: 'weather-outfit-recommender',
-    }));
-    expect(store.github.repos['alex.park/weather-outfit-recommender']).toBeDefined();
+  it('partial updates only touch the fields provided', async () => {
+    await h.fetch('/__fws/setup/github/user', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ login: 'alex.park', name: 'Alex Park', email: 'alex@x.io' }),
+    });
+    // Only update email.
+    await h.fetch('/__fws/setup/github/user', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email: 'alex.park@platform.internal' }),
+    });
+    const me = await (await h.fetch('/user')).json();
+    expect(me.login).toBe('alex.park');
+    expect(me.name).toBe('Alex Park');
+    expect(me.email).toBe('alex.park@platform.internal');
   });
 });


### PR DESCRIPTION
## Summary

Closes #30. Lets an operator change the GitHub `user.login` that fws stamps on newly created issues / PRs / comments, so an LLM agent doesn't see `testuser` and shortcut the task.

Two ways to set the identity:

1. **Initial value at server start** (env vars, optional):
   ```bash
   FWS_USER_LOGIN=alex.park \
   FWS_USER_NAME="Alex Park" \
   FWS_USER_EMAIL=alex.park@platform.internal \
   fws server start
   ```

2. **Runtime, including switching mid-session** (new CLI command):
   ```bash
   fws github user set --login alex.park --name "Alex Park"
   gh issue create -t "..." -b "..."   # → user.login = alex.park

   fws github user set --login david.kim --name "David Kim"
   gh issue create -t "..." -b "..."   # → user.login = david.kim
   ```

Backed by a new `POST /__fws/setup/github/user` endpoint that mutates `store.github.user` (and `store.gmail.profile.displayName`, since Drive owner / Gmail sendAs share the display name).

### Repo handling

Repo override (`FWS_GITHUB_REPO`) is **not** part of this PR. `gh` reads owner/repo from the current checkout's `.git/config`, so the right way to work against `platform/weather-outfit-recommender` is to create that repo at runtime (`gh repo create`, the on-disk bare-repo setup endpoint, or `git clone http://localhost:4100/git/platform/weather-outfit-recommender.git`) and operate from inside its checkout. The store is keyed by repo full_name, so multi-repo is natural — no env var needed.

`fws server env` no longer exports `GH_REPO` for this reason; the start banner explains the `.git/config` flow. Run gh outside a checkout? Prefix the call with `GH_REPO=owner/repo`.

### Behind the scenes

- `displayName` added to `GmailProfile` so drive / gmail / control routes can read the configured name from the store instead of hardcoding `"Test User"`. The runtime user-set endpoint updates this too.
- Seeded repo full_name is `${login}/my-project` (so `FWS_USER_LOGIN=alex.park` → `alex.park/my-project`).
- Snapshots already capture the live identity through normal store serialization.

## Test plan

- [x] `npx vitest run --project unit` — 193 / 193 pass. Includes 4 new tests in `test/seed-identity.test.ts`:
  - default `testuser` identity when no env vars
  - `FWS_USER_LOGIN/NAME/EMAIL` set the initial seeded user (login flows to `repos/${login}/my-project`, PR head label, drive owner, gmail sendAs)
  - runtime `POST /__fws/setup/github/user` alternates the author of newly created issues
  - partial updates only touch the fields provided
- [x] Smoke test: started server, ran `fws github user set --login alex.park`, posted issue → `user.login = alex.park`. Switched to `david.kim`, posted again → `user.login = david.kim`. Both stamps verified live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)