### PR TITLE
fix(fetch): canonicalize URLs in fixture lookup so trailing slashes match

### DIFF
--- a/src/server/routes/fetch.ts
+++ b/src/server/routes/fetch.ts
@@ -191,6 +191,32 @@ interface LookupResult {
   response: WebFetchResponse;
 }
 
+/**
+ * Canonical form used for URL-based fixture lookup. Real-world callers
+ * routinely vary trailing slashes on directory-style paths
+ * (`/business` vs `/business/`); without normalization those count as
+ * distinct fixtures and lookups silently miss. We canonicalize by stripping
+ * a trailing slash from non-root paths and leaving search/hash untouched.
+ *
+ * Hostnames, ports, schemes, query strings, and fragments are passed through
+ * `URL` parsing so they are normalized in the same way the WHATWG spec does
+ * (e.g. lowercased host, default-port elision). Inputs that don't parse as
+ * URLs are returned unchanged so callers can still register exotic fixture
+ * keys if they need to.
+ */
+function canonicalUrl(input: string): string {
+  try {
+    const u = new URL(input);
+    let path = u.pathname;
+    if (path.length > 1 && path.endsWith('/')) {
+      path = path.slice(0, -1);
+    }
+    return `${u.protocol}//${u.host}${path}${u.search}${u.hash}`;
+  } catch {
+    return input;
+  }
+}
+
 function lookupFixture(url: string, method: string): LookupResult {
   const store = getStore();
   const upperMethod = method.toUpperCase();
@@ -202,10 +228,11 @@ function lookupFixture(url: string, method: string): LookupResult {
     // not parseable — host-only matches won't fire
   }
 
-  // 1. Exact URL match (with optional method filter)
+  // 1. URL match (canonicalized so trailing-slash variants match).
+  const canonicalIncoming = canonicalUrl(url);
   for (const fix of store.webFetch.fixtures) {
     if (!fix.url) continue;
-    if (fix.url !== url) continue;
+    if (canonicalUrl(fix.url) !== canonicalIncoming) continue;
     if (fix.method && fix.method.toUpperCase() !== upperMethod) continue;
     return { matched: 'url', fixture: fix, response: fix.response };
   }

--- a/test/fetch.test.ts
+++ b/test/fetch.test.ts
@@ -148,6 +148,58 @@ describe('Web Fetch (generic HTTP/HTTPS mock)', () => {
       expect(postData.matched).toBe('url');
       expect(postData.response.body).toBe('post-only');
     });
+
+    it('matches fixtures regardless of trailing slash on the path', async () => {
+      // Register without trailing slash, look up with one.
+      await h.fetch('/__fws/setup/fetch/fixture', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          url: 'https://slash.test/page',
+          response: { status: 200, headers: { 'content-type': 'text/plain' }, body: 'page-no-slash' },
+        }),
+      });
+
+      const exact = await h.fetch('/__fws/fetch?url=' + encodeURIComponent('https://slash.test/page'));
+      expect((await exact.json()).matched).toBe('url');
+
+      const trailing = await h.fetch('/__fws/fetch?url=' + encodeURIComponent('https://slash.test/page/'));
+      const trailingData = await trailing.json();
+      expect(trailingData.matched).toBe('url');
+      expect(trailingData.response.body).toBe('page-no-slash');
+
+      // Inverse: register with trailing slash, look up without.
+      await h.fetch('/__fws/setup/fetch/fixture', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          url: 'https://slash.test/dir/',
+          response: { status: 200, headers: { 'content-type': 'text/plain' }, body: 'dir-with-slash' },
+        }),
+      });
+
+      const noSlash = await h.fetch('/__fws/fetch?url=' + encodeURIComponent('https://slash.test/dir'));
+      const noSlashData = await noSlash.json();
+      expect(noSlashData.matched).toBe('url');
+      expect(noSlashData.response.body).toBe('dir-with-slash');
+    });
+
+    it('preserves the root "/" path when canonicalizing', async () => {
+      await h.fetch('/__fws/setup/fetch/fixture', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          url: 'https://root-slash.test/',
+          response: { status: 200, body: 'root' },
+        }),
+      });
+
+      const withSlash = await h.fetch('/__fws/fetch?url=' + encodeURIComponent('https://root-slash.test/'));
+      expect((await withSlash.json()).matched).toBe('url');
+
+      const noSlash = await h.fetch('/__fws/fetch?url=' + encodeURIComponent('https://root-slash.test'));
+      expect((await noSlash.json()).matched).toBe('url');
+    });
   });
 
   describe('catch-all middleware (simulated proxy headers)', () => {


### PR DESCRIPTION
## Problem

`lookupFixture` in `src/server/routes/fetch.ts` compared `fix.url !== url` as raw strings. Real callers routinely vary trailing slashes on directory-style paths (`/business` vs `/business/`), but strict string equality counts those as distinct fixtures. The result is a fixture registered for `https://example.com/business` silently falls through to the hardcoded `fws-web-fetch-default` mock when the client fetches `https://example.com/business/`.

This also bites the host-only fallback. A fixture registered with `url:` (not `host:`) only enters step 1 of the lookup, so the trailing-slash variant skips the URL match and never reaches the host-only branch either.

## Repro

```ts
// register
POST /__fws/setup/fetch/fixture
{ "url": "https://example.com/business",
  "response": { "status": 200, "body": "real content" } }

// look up the same path with a trailing slash
GET /__fws/fetch?url=https%3A%2F%2Fexample.com%2Fbusiness%2F
// → matched: 'default'   ❌  (expected: 'url')
```

## Fix

Add a small `canonicalUrl` helper that strips a single trailing slash from non-root paths and otherwise round-trips URLs through `URL` parsing (so hostnames, ports, default-port elision, etc. are normalized the same way the WHATWG spec does). Use it on both sides of the URL-match comparison in `lookupFixture`. Inputs that don't parse as URLs are returned unchanged so callers can still register exotic fixture keys.

The root path `/` is preserved (we only strip when `path.length > 1`), so a fixture registered for `https://example.com/` continues to match both `https://example.com` and `https://example.com/`.

## Tests

`test/fetch.test.ts` adds two cases inside the `runtime fixture injection` block:

- `matches fixtures regardless of trailing slash on the path` — covers both directions (register without slash → look up with slash, and the inverse) and asserts the matched fixture's body, not just the `matched` flag, so it catches accidental host-fallback matches too.
- `preserves the root "/" path when canonicalizing` — sanity check that `/` is never stripped.

Full suite: `npx vitest run test/fetch.test.ts` → 17/17 passing locally.

## Out of scope

This PR only handles trailing-slash normalization on the path. Other URL-equivalence concerns — query-parameter ordering, default-port elision beyond what `URL` already does, fragment handling, percent-encoding case — are intentionally left alone. They can be addressed as separate, narrowly-scoped follow-ups if real fixture mismatches show up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)