### PR TITLE
fix(gmail): include `raw` field in `?format=raw` response

### DIFF
--- a/src/server/routes/gmail.ts
+++ b/src/server/routes/gmail.ts
@@ -65,7 +65,19 @@ export function gmailRoutes(): Router {
       return res.json({ id: msg.id, threadId: msg.threadId, labelIds: msg.labelIds, snippet: msg.snippet, historyId: msg.historyId, internalDate: msg.internalDate, sizeEstimate: msg.sizeEstimate, payload: { headers: msg.payload.headers } });
     }
     if (format === 'raw') {
-      return res.json({ ...msg });
+      // gws `+read --headers` requires `payload.headers` to contain Message-ID
+      // AND the `raw` field to be a base64url-encoded RFC 2822 message. Without
+      // `raw`, gws aborts the read with "Message is missing Message-ID header"
+      // because it parses headers from `raw`, not from `payload.headers`.
+      const headerLines = msg.payload.headers
+        .map((h) => `${h.name}: ${h.value}`)
+        .join('\r\n');
+      const bodyText = msg.payload.body?.data
+        ? Buffer.from(msg.payload.body.data, 'base64url').toString('utf-8')
+        : '';
+      const rawText = `${headerLines}\r\n\r\n${bodyText}`;
+      const raw = Buffer.from(rawText, 'utf-8').toString('base64url');
+      return res.json({ ...msg, raw });
     }
     // full
     res.json(msg);


### PR DESCRIPTION
## Summary

The Gmail API spec for `messages.get?format=raw` returns the full RFC 2822 message as a base64url-encoded `raw` field. fws currently returns the message without the `raw` field — only `payload.headers` is populated.

This breaks any client that parses headers from `raw`. Concrete example: gws's `gmail +read --headers` aborts with `Message is missing Message-ID header` because gws parses headers from `raw`, not from `payload.headers`.

## Change

Rebuild a minimal RFC 2822 representation from `payload.headers` + `payload.body.data` and emit it as the `raw` field. ~13 LoC, no behavior change for `format=full|metadata|minimal`.

## Limitations

Multipart messages reconstruct with an empty body because the body lives in `payload.parts`, not `payload.body.data`. fws's default fixtures are single-part text/plain so this covers the common case; multipart support is left as a follow-up.

## Test plan

- [ ] Existing `vitest` suite still passes (no test relied on `raw` being absent).
- [ ] `gws gmail +read --headers <message-id>` against an fws-backed gmail mock now succeeds (was failing).
- [ ] Manual: `curl 'http://localhost:4100/gmail/v1/users/me/messages/<id>?format=raw'` returns a `raw` field with a valid base64url RFC 2822 message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)